### PR TITLE
認証設定の管理画面を実装

### DIFF
--- a/app/controllers/admin/auth_settings_controller.rb
+++ b/app/controllers/admin/auth_settings_controller.rb
@@ -1,0 +1,23 @@
+module Admin
+  class AuthSettingsController < BaseController
+    def show
+      @auth_setting = AuthSetting.instance
+    end
+
+    def update
+      @auth_setting = AuthSetting.instance
+
+      if @auth_setting.update(auth_setting_params)
+        redirect_to admin_auth_settings_path, notice: "認証設定を更新しました。"
+      else
+        render :show, status: :unprocessable_entity
+      end
+    end
+
+    private
+
+    def auth_setting_params
+      params.require(:auth_setting).permit(:local_auth_enabled, :local_auth_show_on_login)
+    end
+  end
+end

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,0 +1,11 @@
+module Admin
+  class BaseController < ApplicationController
+    before_action :require_admin
+
+    private
+
+    def require_admin
+      redirect_to root_path, alert: "管理者権限が必要です。" unless current_user&.admin?
+    end
+  end
+end

--- a/app/controllers/admin/identity_providers_controller.rb
+++ b/app/controllers/admin/identity_providers_controller.rb
@@ -1,0 +1,67 @@
+module Admin
+  class IdentityProvidersController < BaseController
+    before_action :set_identity_provider, only: %i[show edit update destroy]
+
+    def index
+      @identity_providers = IdentityProvider.order(:provider_type, :name)
+    end
+
+    def show
+    end
+
+    def new
+      @identity_provider = IdentityProvider.new(
+        provider_type: params[:provider_type] || "saml",
+        settings: {}
+      )
+    end
+
+    def edit
+    end
+
+    def create
+      @identity_provider = IdentityProvider.new(identity_provider_params)
+
+      if @identity_provider.save
+        redirect_to admin_identity_providers_path,
+          notice: "IdP を作成しました。設定を反映するにはアプリを再起動してください。"
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    def update
+      if @identity_provider.update(identity_provider_params)
+        redirect_to admin_identity_providers_path,
+          notice: "IdP を更新しました。設定を反映するにはアプリを再起動してください。"
+      else
+        render :edit, status: :unprocessable_entity
+      end
+    end
+
+    def destroy
+      @identity_provider.destroy
+      redirect_to admin_identity_providers_path,
+        notice: "IdP を削除しました。設定を反映するにはアプリを再起動してください。"
+    end
+
+    private
+
+    def set_identity_provider
+      @identity_provider = IdentityProvider.find(params[:id])
+    end
+
+    def identity_provider_params
+      permitted = params.require(:identity_provider).permit(
+        :provider_type, :name, :slug, :enabled, :show_on_login
+      )
+
+      # settings をネストしたパラメータから取得
+      if params[:identity_provider][:settings].present?
+        permitted[:settings] = params[:identity_provider][:settings].to_unsafe_h
+      end
+
+      permitted
+    end
+  end
+end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,12 +1,17 @@
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   skip_before_action :verify_authenticity_token, only: %i[saml]
 
-  def saml
-    handle_omniauth("SAML")
+  # 動的に IdP のコールバックを処理
+  def method_missing(method_name, *args)
+    if method_name.to_s.start_with?("saml_", "oidc_")
+      handle_omniauth(method_name.to_s)
+    else
+      super
+    end
   end
 
-  def openid_connect
-    handle_omniauth("OIDC")
+  def respond_to_missing?(method_name, include_private = false)
+    method_name.to_s.start_with?("saml_", "oidc_") || super
   end
 
   def failure
@@ -16,13 +21,19 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   private
 
   def handle_omniauth(provider_name)
-    @user = User.from_omniauth(request.env["omniauth.auth"])
+    auth = request.env["omniauth.auth"]
+    @user = User.from_omniauth(auth)
 
     if @user.persisted?
+      # IdP 名を取得して表示
+      idp_slug = provider_name.sub(/^(saml|oidc)_/, "")
+      idp = IdentityProvider.find_by(slug: idp_slug)
+      display_name = idp&.name || provider_name.upcase
+
       sign_in_and_redirect @user, event: :authentication
-      set_flash_message(:notice, :success, kind: provider_name) if is_navigational_format?
+      set_flash_message(:notice, :success, kind: display_name) if is_navigational_format?
     else
-      redirect_to root_path, alert: "#{provider_name} 認証に失敗しました。"
+      redirect_to root_path, alert: "認証に失敗しました。"
     end
   end
 end

--- a/app/models/auth_setting.rb
+++ b/app/models/auth_setting.rb
@@ -1,0 +1,14 @@
+class AuthSetting < ApplicationRecord
+  # シングルトンとして使用
+  def self.instance
+    first_or_create!
+  end
+
+  def self.local_auth_enabled?
+    instance.local_auth_enabled
+  end
+
+  def self.local_auth_show_on_login?
+    instance.local_auth_show_on_login
+  end
+end

--- a/app/models/identity_provider.rb
+++ b/app/models/identity_provider.rb
@@ -1,0 +1,42 @@
+class IdentityProvider < ApplicationRecord
+  PROVIDER_TYPES = %w[saml oidc].freeze
+
+  validates :provider_type, presence: true, inclusion: { in: PROVIDER_TYPES }
+  validates :name, presence: true
+  validates :slug, presence: true, uniqueness: true, format: { with: /\A[a-z0-9_-]+\z/ }
+  validates :settings, presence: true
+
+  scope :enabled, -> { where(enabled: true) }
+  scope :visible_on_login, -> { where(show_on_login: true) }
+  scope :saml, -> { where(provider_type: "saml") }
+  scope :oidc, -> { where(provider_type: "oidc") }
+
+  before_validation :generate_slug, on: :create
+
+  def saml?
+    provider_type == "saml"
+  end
+
+  def oidc?
+    provider_type == "oidc"
+  end
+
+  def omniauth_provider_name
+    "#{provider_type}_#{slug}".to_sym
+  end
+
+  private
+
+  def generate_slug
+    return if slug.present?
+
+    base_slug = name.to_s.parameterize
+    self.slug = base_slug
+
+    counter = 1
+    while IdentityProvider.exists?(slug: slug)
+      self.slug = "#{base_slug}-#{counter}"
+      counter += 1
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable
   devise :database_authenticatable,
          :recoverable, :rememberable, :validatable,
-         :omniauthable, omniauth_providers: %i[saml openid_connect]
+         :omniauthable
 
   def self.from_omniauth(auth)
     # メールアドレスで既存ユーザーを検索、なければ作成

--- a/app/views/admin/auth_settings/show.html.erb
+++ b/app/views/admin/auth_settings/show.html.erb
@@ -1,0 +1,39 @@
+<h1>認証設定</h1>
+
+<%= form_with model: @auth_setting, url: admin_auth_settings_path, method: :patch do |f| %>
+  <% if @auth_setting.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= @auth_setting.errors.count %>件のエラーがあります:</h2>
+      <ul>
+        <% @auth_setting.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <h2>ローカル認証</h2>
+
+  <div>
+    <%= f.label :local_auth_enabled, "ローカル認証を有効にする" %>
+    <%= f.check_box :local_auth_enabled %>
+  </div>
+
+  <div>
+    <%= f.label :local_auth_show_on_login, "ログイン画面にローカル認証フォームを表示" %>
+    <%= f.check_box :local_auth_show_on_login %>
+  </div>
+
+  <h2>外部 IdP</h2>
+  <p>
+    登録済み IdP: <%= IdentityProvider.count %> 件
+    （有効: <%= IdentityProvider.enabled.count %> 件）
+  </p>
+  <p><%= link_to "IdP 設定を管理", admin_identity_providers_path %></p>
+
+  <div>
+    <%= f.submit "保存" %>
+  </div>
+<% end %>
+
+<p><%= link_to "ダッシュボードへ戻る", root_path %></p>

--- a/app/views/admin/identity_providers/_form.html.erb
+++ b/app/views/admin/identity_providers/_form.html.erb
@@ -1,0 +1,104 @@
+<%= form_with model: [:admin, @identity_provider] do |f| %>
+  <% if @identity_provider.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= @identity_provider.errors.count %>件のエラーがあります:</h2>
+      <ul>
+        <% @identity_provider.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <%= f.hidden_field :provider_type %>
+
+  <div>
+    <%= f.label :name, "表示名" %>
+    <%= f.text_field :name, required: true %>
+  </div>
+
+  <div>
+    <%= f.label :slug, "スラッグ（URL用識別子）" %>
+    <%= f.text_field :slug, placeholder: "自動生成されます" %>
+    <small>英小文字、数字、ハイフン、アンダースコアのみ</small>
+  </div>
+
+  <div>
+    <%= f.label :enabled, "有効" %>
+    <%= f.check_box :enabled %>
+  </div>
+
+  <div>
+    <%= f.label :show_on_login, "ログイン画面に表示" %>
+    <%= f.check_box :show_on_login %>
+  </div>
+
+  <hr>
+  <h3><%= @identity_provider.provider_type&.upcase %> 設定</h3>
+
+  <% if @identity_provider.provider_type == "saml" %>
+    <div>
+      <%= label_tag "settings_idp_sso_url", "IdP SSO URL" %>
+      <%= text_field_tag "identity_provider[settings][idp_sso_url]",
+          @identity_provider.settings&.dig("idp_sso_url"),
+          id: "settings_idp_sso_url", required: true %>
+    </div>
+
+    <div>
+      <%= label_tag "settings_idp_slo_url", "IdP SLO URL（任意）" %>
+      <%= text_field_tag "identity_provider[settings][idp_slo_url]",
+          @identity_provider.settings&.dig("idp_slo_url"),
+          id: "settings_idp_slo_url" %>
+    </div>
+
+    <div>
+      <%= label_tag "settings_idp_cert", "IdP 証明書" %>
+      <%= text_area_tag "identity_provider[settings][idp_cert]",
+          @identity_provider.settings&.dig("idp_cert"),
+          id: "settings_idp_cert", rows: 10 %>
+    </div>
+
+    <div>
+      <%= label_tag "settings_sp_entity_id", "SP エンティティ ID" %>
+      <%= text_field_tag "identity_provider[settings][sp_entity_id]",
+          @identity_provider.settings&.dig("sp_entity_id") || "kulip",
+          id: "settings_sp_entity_id" %>
+    </div>
+
+  <% elsif @identity_provider.provider_type == "oidc" %>
+    <div>
+      <%= label_tag "settings_issuer", "Issuer URL" %>
+      <%= text_field_tag "identity_provider[settings][issuer]",
+          @identity_provider.settings&.dig("issuer"),
+          id: "settings_issuer", required: true %>
+    </div>
+
+    <div>
+      <%= label_tag "settings_client_id", "Client ID" %>
+      <%= text_field_tag "identity_provider[settings][client_id]",
+          @identity_provider.settings&.dig("client_id"),
+          id: "settings_client_id", required: true %>
+    </div>
+
+    <div>
+      <%= label_tag "settings_client_secret", "Client Secret" %>
+      <%= password_field_tag "identity_provider[settings][client_secret]",
+          @identity_provider.settings&.dig("client_secret"),
+          id: "settings_client_secret", required: true %>
+    </div>
+
+    <div>
+      <%= label_tag "settings_redirect_uri", "Redirect URI" %>
+      <%= text_field_tag "identity_provider[settings][redirect_uri]",
+          @identity_provider.settings&.dig("redirect_uri"),
+          id: "settings_redirect_uri",
+          placeholder: "#{request.base_url}/users/auth/oidc_#{@identity_provider.slug || 'SLUG'}/callback" %>
+    </div>
+  <% end %>
+
+  <div>
+    <%= f.submit %>
+  </div>
+<% end %>
+
+<p><%= link_to "戻る", admin_identity_providers_path %></p>

--- a/app/views/admin/identity_providers/edit.html.erb
+++ b/app/views/admin/identity_providers/edit.html.erb
@@ -1,0 +1,3 @@
+<h1><%= @identity_provider.name %> を編集</h1>
+
+<%= render "form" %>

--- a/app/views/admin/identity_providers/index.html.erb
+++ b/app/views/admin/identity_providers/index.html.erb
@@ -1,0 +1,41 @@
+<h1>IdP 設定</h1>
+
+<p>
+  <%= link_to "SAML IdP を追加", new_admin_identity_provider_path(provider_type: "saml") %> |
+  <%= link_to "OIDC IdP を追加", new_admin_identity_provider_path(provider_type: "oidc") %>
+</p>
+
+<% if @identity_providers.any? %>
+  <table>
+    <thead>
+      <tr>
+        <th>種別</th>
+        <th>名前</th>
+        <th>スラッグ</th>
+        <th>有効</th>
+        <th>ログイン画面に表示</th>
+        <th>操作</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @identity_providers.each do |idp| %>
+        <tr>
+          <td><%= idp.provider_type.upcase %></td>
+          <td><%= idp.name %></td>
+          <td><%= idp.slug %></td>
+          <td><%= idp.enabled? ? "有効" : "無効" %></td>
+          <td><%= idp.show_on_login? ? "表示" : "非表示" %></td>
+          <td>
+            <%= link_to "編集", edit_admin_identity_provider_path(idp) %> |
+            <%= link_to "削除", admin_identity_provider_path(idp), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <p>IdP が登録されていません。</p>
+<% end %>
+
+<p><%= link_to "認証設定へ", admin_auth_settings_path %></p>
+<p><%= link_to "ダッシュボードへ戻る", root_path %></p>

--- a/app/views/admin/identity_providers/new.html.erb
+++ b/app/views/admin/identity_providers/new.html.erb
@@ -1,0 +1,3 @@
+<h1><%= @identity_provider.provider_type&.upcase %> IdP を追加</h1>
+
+<%= render "form" %>

--- a/app/views/admin/identity_providers/show.html.erb
+++ b/app/views/admin/identity_providers/show.html.erb
@@ -1,0 +1,23 @@
+<h1><%= @identity_provider.name %></h1>
+
+<dl>
+  <dt>種別</dt>
+  <dd><%= @identity_provider.provider_type.upcase %></dd>
+
+  <dt>スラッグ</dt>
+  <dd><%= @identity_provider.slug %></dd>
+
+  <dt>有効</dt>
+  <dd><%= @identity_provider.enabled? ? "有効" : "無効" %></dd>
+
+  <dt>ログイン画面に表示</dt>
+  <dd><%= @identity_provider.show_on_login? ? "表示" : "非表示" %></dd>
+
+  <dt>設定</dt>
+  <dd><pre><%= JSON.pretty_generate(@identity_provider.settings) %></pre></dd>
+</dl>
+
+<p>
+  <%= link_to "編集", edit_admin_identity_provider_path(@identity_provider) %> |
+  <%= link_to "戻る", admin_identity_providers_path %>
+</p>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -3,7 +3,11 @@
 <p>ようこそ、<%= current_user.email %> さん</p>
 
 <% if current_user.admin? %>
-  <p><strong>管理者</strong></p>
+  <h2>管理者メニュー</h2>
+  <ul>
+    <li><%= link_to "認証設定", admin_auth_settings_path %></li>
+    <li><%= link_to "IdP 設定", admin_identity_providers_path %></li>
+  </ul>
 <% end %>
 
 <p><%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete } %></p>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,0 +1,46 @@
+<h2>ログイン</h2>
+
+<% if AuthSetting.local_auth_enabled? && AuthSetting.local_auth_show_on_login? %>
+  <h3>メールアドレスでログイン</h3>
+  <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+    <div>
+      <%= f.label :email, "メールアドレス" %>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    </div>
+
+    <div>
+      <%= f.label :password, "パスワード" %>
+      <%= f.password_field :password, autocomplete: "current-password" %>
+    </div>
+
+    <% if devise_mapping.rememberable? %>
+      <div>
+        <%= f.check_box :remember_me %>
+        <%= f.label :remember_me, "ログイン状態を保持" %>
+      </div>
+    <% end %>
+
+    <div>
+      <%= f.submit "ログイン" %>
+    </div>
+  <% end %>
+<% end %>
+
+<% visible_idps = IdentityProvider.enabled.visible_on_login %>
+<% if visible_idps.any? %>
+  <h3>外部サービスでログイン</h3>
+  <ul>
+    <% visible_idps.each do |idp| %>
+      <li>
+        <%= button_to idp.name,
+            user_omniauth_authorize_path(idp.omniauth_provider_name),
+            method: :post,
+            data: { turbo: false } %>
+      </li>
+    <% end %>
+  </ul>
+<% end %>
+
+<% unless AuthSetting.local_auth_show_on_login? || visible_idps.any? %>
+  <p>利用可能なログイン方法がありません。管理者に連絡してください。</p>
+<% end %>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,0 +1,15 @@
+<% if resource.errors.any? %>
+  <div id="error_explanation" data-turbo-temporary>
+    <h2>
+      <%= I18n.t("errors.messages.not_saved",
+                 count: resource.errors.count,
+                 resource: resource.class.model_name.human.downcase)
+       %>
+    </h2>
+    <ul>
+      <% resource.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,0 +1,25 @@
+<%- if controller_name != 'sessions' %>
+  <p><%= link_to "Log in", new_session_path(resource_name) %></p>
+<% end %>
+
+<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+  <p><%= link_to "Sign up", new_registration_path(resource_name) %></p>
+<% end %>
+
+<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+  <p><%= link_to "Forgot your password?", new_password_path(resource_name) %></p>
+<% end %>
+
+<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+  <p><%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %></p>
+<% end %>
+
+<%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
+  <p><%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %></p>
+<% end %>
+
+<%- if devise_mapping.omniauthable? %>
+  <%- resource_class.omniauth_providers.each do |provider| %>
+    <p><%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false } %></p>
+  <% end %>
+<% end %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -275,32 +275,40 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
 
-  # SAML 認証（環境変数で設定）
-  if ENV["SAML_IDP_SSO_URL"].present?
-    config.omniauth :saml,
-      idp_sso_service_url: ENV["SAML_IDP_SSO_URL"],
-      idp_slo_service_url: ENV["SAML_IDP_SLO_URL"],
-      idp_cert: ENV["SAML_IDP_CERT"],
-      sp_entity_id: ENV.fetch("SAML_SP_ENTITY_ID", "kulip"),
-      name_identifier_format: "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
-      attribute_statements: {
-        email: [ "email", "mail", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress" ]
-      }
-  end
-
-  # OIDC 認証（環境変数で設定）
-  if ENV["OIDC_ISSUER"].present?
-    config.omniauth :openid_connect,
-      name: :openid_connect,
-      scope: %i[openid email profile],
-      response_type: :code,
-      issuer: ENV["OIDC_ISSUER"],
-      discovery: true,
-      client_options: {
-        identifier: ENV["OIDC_CLIENT_ID"],
-        secret: ENV["OIDC_CLIENT_SECRET"],
-        redirect_uri: ENV["OIDC_REDIRECT_URI"]
-      }
+  # DB から IdP を読み込んで OmniAuth プロバイダを設定
+  # 注意: IdP を追加・変更した後はアプリの再起動が必要
+  begin
+    if defined?(IdentityProvider) && ActiveRecord::Base.connection.table_exists?("identity_providers")
+      IdentityProvider.enabled.find_each do |idp|
+      case idp.provider_type
+      when "saml"
+        config.omniauth :saml,
+          name: "saml_#{idp.slug}",
+          idp_sso_service_url: idp.settings["idp_sso_url"],
+          idp_slo_service_url: idp.settings["idp_slo_url"],
+          idp_cert: idp.settings["idp_cert"],
+          sp_entity_id: idp.settings["sp_entity_id"] || "kulip",
+          name_identifier_format: "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
+          attribute_statements: {
+            email: [ "email", "mail", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress" ]
+          }
+      when "oidc"
+        config.omniauth :openid_connect,
+          name: "oidc_#{idp.slug}",
+          scope: %i[openid email profile],
+          response_type: :code,
+          issuer: idp.settings["issuer"],
+          discovery: true,
+          client_options: {
+            identifier: idp.settings["client_id"],
+            secret: idp.settings["client_secret"],
+            redirect_uri: idp.settings["redirect_uri"]
+          }
+      end
+      end
+    end
+  rescue StandardError
+    # マイグレーション前やテーブルが存在しない場合はスキップ
   end
 
   # ==> Warden configuration

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,12 @@ Rails.application.routes.draw do
   # ダッシュボード（ルート）
   root "dashboard#index"
 
+  # 管理者画面
+  namespace :admin do
+    resources :identity_providers
+    resource :auth_settings, only: %i[show update]
+  end
+
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check

--- a/db/migrate/20260317055800_create_identity_providers.rb
+++ b/db/migrate/20260317055800_create_identity_providers.rb
@@ -1,0 +1,18 @@
+class CreateIdentityProviders < ActiveRecord::Migration[8.1]
+  def change
+    create_table :identity_providers do |t|
+      t.string :provider_type, null: false
+      t.string :name, null: false
+      t.string :slug, null: false
+      t.boolean :enabled, null: false, default: false
+      t.boolean :show_on_login, null: false, default: true
+      t.json :settings, null: false, default: {}
+
+      t.timestamps
+    end
+
+    add_index :identity_providers, :slug, unique: true
+    add_index :identity_providers, :provider_type
+    add_index :identity_providers, :enabled
+  end
+end

--- a/db/migrate/20260317062824_create_auth_settings.rb
+++ b/db/migrate/20260317062824_create_auth_settings.rb
@@ -1,0 +1,10 @@
+class CreateAuthSettings < ActiveRecord::Migration[8.1]
+  def change
+    create_table :auth_settings do |t|
+      t.boolean :local_auth_enabled, null: false, default: true
+      t.boolean :local_auth_show_on_login, null: false, default: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,28 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_16_044132) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_17_062824) do
+  create_table "auth_settings", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.boolean "local_auth_enabled", default: true, null: false
+    t.boolean "local_auth_show_on_login", default: true, null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "identity_providers", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.boolean "enabled", default: false, null: false
+    t.string "name", null: false
+    t.string "provider_type", null: false
+    t.json "settings", default: {}, null: false
+    t.boolean "show_on_login", default: true, null: false
+    t.string "slug", null: false
+    t.datetime "updated_at", null: false
+    t.index ["enabled"], name: "index_identity_providers_on_enabled"
+    t.index ["provider_type"], name: "index_identity_providers_on_provider_type"
+    t.index ["slug"], name: "index_identity_providers_on_slug", unique: true
+  end
+
   create_table "users", force: :cascade do |t|
     t.boolean "admin", default: false, null: false
     t.datetime "created_at", null: false

--- a/test/fixtures/auth_settings.yml
+++ b/test/fixtures/auth_settings.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  local_auth_enabled: false
+  local_auth_show_on_login: false
+
+two:
+  local_auth_enabled: false
+  local_auth_show_on_login: false

--- a/test/fixtures/identity_providers.yml
+++ b/test/fixtures/identity_providers.yml
@@ -1,0 +1,17 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  provider_type: MyString
+  name: MyString
+  slug: MyString
+  enabled: false
+  show_on_login: false
+  settings: 
+
+two:
+  provider_type: MyString
+  name: MyString
+  slug: MyString
+  enabled: false
+  show_on_login: false
+  settings: 

--- a/test/models/auth_setting_test.rb
+++ b/test/models/auth_setting_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class AuthSettingTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/identity_provider_test.rb
+++ b/test/models/identity_provider_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class IdentityProviderTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## Summary

- IdP 設定を DB で管理（複数の SAML/OIDC IdP に対応）
- 認証設定を管理画面から制御可能に
- ログイン画面を設定に基づいて動的に生成

## 新機能

### IdentityProvider モデル
- SAML/OIDC の IdP 設定を DB で管理
- 複数の IdP を登録可能
- 有効/無効、ログイン画面表示の制御

### AuthSetting モデル（シングルトン）
- ローカル認証の有効/無効
- ローカル認証フォームの表示設定

### 管理者画面
- `/admin/identity_providers` - IdP の追加・編集・削除
- `/admin/auth_settings` - 認証設定

### ログイン画面
- 設定に基づいて動的に表示
- ローカル認証フォーム + 外部 IdP ボタン

## 注意事項

- IdP を追加・変更した後はアプリの再起動が必要
- OmniAuth のプロバイダ設定は Rails 起動時に行われるため

## Test plan

- [x] `bin/rails test` が実行できる
- [x] `bin/rubocop` がエラーなく実行できる
- [ ] 管理画面から IdP を追加できる
- [ ] 認証設定を変更できる
- [ ] ログイン画面が設定に基づいて表示される

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)