### PR TITLE
文字起こし API クライアントを実装

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# OCR API 設定
+OCR_API_ENDPOINT=https://api.example.com/v1/ocr
+OCR_API_KEY=your_api_key_here
+OCR_API_TIMEOUT=60

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -1,6 +1,6 @@
 class ImagesController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_image, only: %i[show destroy]
+  before_action :set_image, only: %i[show destroy retry]
 
   def index
     @images = current_user.images.recent.with_attached_file
@@ -40,6 +40,14 @@ class ImagesController < ApplicationController
   def destroy
     @image.destroy
     redirect_to images_path, notice: "画像を削除しました。"
+  end
+
+  def retry
+    if @image.retry_ocr!
+      redirect_to image_path(@image), notice: "OCR 処理を再実行しました。"
+    else
+      redirect_to image_path(@image), alert: "OCR 処理を再実行できません。"
+    end
   end
 
   private

--- a/app/jobs/ocr_process_job.rb
+++ b/app/jobs/ocr_process_job.rb
@@ -1,0 +1,44 @@
+class OcrProcessJob < ApplicationJob
+  queue_as :default
+
+  retry_on OcrApiClient::TimeoutError, wait: 30.seconds, attempts: 3
+  retry_on OcrApiClient::RequestError, wait: 1.minute, attempts: 2
+  discard_on OcrApiClient::ConfigurationError
+
+  def perform(image_id)
+    image = Image.find_by(id: image_id)
+    return unless image
+    return unless image.pending?
+    return unless image.file.attached?
+
+    process_image(image)
+  end
+
+  private
+
+  def process_image(image)
+    image.update!(status: "processing")
+
+    client = OcrApiClient.new
+    result = client.transcribe(
+      image_data: image.file.download,
+      filename: image.file.filename.to_s,
+      content_type: image.file.content_type
+    )
+
+    # API のレスポンス形式に応じて結果を保存
+    ocr_text = extract_text_from_result(result)
+    image.update!(status: "completed", ocr_result: ocr_text)
+
+  rescue OcrApiClient::Error => e
+    Rails.logger.error "OCR processing failed for image #{image.id}: #{e.message}"
+    image.update!(status: "failed", ocr_result: "Error: #{e.message}")
+    raise
+  end
+
+  def extract_text_from_result(result)
+    # API のレスポンス形式に応じてテキストを抽出
+    # 一般的なフォーマットをサポート
+    result[:text] || result[:markdown] || result[:content] || result.to_json
+  end
+end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -8,6 +8,8 @@ class Image < ApplicationRecord
   validates :status, presence: true, inclusion: { in: STATUSES }
   validates :file, presence: true
 
+  after_create_commit :enqueue_ocr_processing
+
   scope :by_status, ->(status) { where(status: status) }
   scope :recent, -> { order(created_at: :desc) }
 
@@ -25,5 +27,21 @@ class Image < ApplicationRecord
 
   def failed?
     status == "failed"
+  end
+
+  # OCR 処理を再実行
+  def retry_ocr!
+    return unless failed? || pending?
+
+    update!(status: "pending", ocr_result: nil)
+    enqueue_ocr_processing
+  end
+
+  private
+
+  def enqueue_ocr_processing
+    return unless OcrApiClient.configured?
+
+    OcrProcessJob.perform_later(id)
   end
 end

--- a/app/services/ocr_api_client.rb
+++ b/app/services/ocr_api_client.rb
@@ -1,0 +1,99 @@
+require "net/http"
+require "uri"
+require "json"
+
+class OcrApiClient
+  class Error < StandardError; end
+  class ConfigurationError < Error; end
+  class RequestError < Error; end
+  class TimeoutError < Error; end
+
+  DEFAULT_TIMEOUT = 60
+
+  def initialize
+    @endpoint = ENV.fetch("OCR_API_ENDPOINT") { raise ConfigurationError, "OCR_API_ENDPOINT is not set" }
+    @api_key = ENV.fetch("OCR_API_KEY") { raise ConfigurationError, "OCR_API_KEY is not set" }
+    @timeout = ENV.fetch("OCR_API_TIMEOUT", DEFAULT_TIMEOUT).to_i
+  end
+
+  # 画像を送信して OCR 結果を取得
+  # @param image_data [String] 画像のバイナリデータ
+  # @param filename [String] ファイル名
+  # @param content_type [String] Content-Type
+  # @return [Hash] OCR 結果
+  def transcribe(image_data:, filename:, content_type:)
+    uri = URI.parse(@endpoint)
+    http = build_http_client(uri)
+
+    request = build_multipart_request(uri, image_data, filename, content_type)
+    response = execute_request(http, request)
+
+    parse_response(response)
+  end
+
+  # API の設定が有効かどうかを確認
+  def self.configured?
+    ENV["OCR_API_ENDPOINT"].present? && ENV["OCR_API_KEY"].present?
+  end
+
+  private
+
+  def build_http_client(uri)
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = uri.scheme == "https"
+    http.open_timeout = @timeout
+    http.read_timeout = @timeout
+    http
+  end
+
+  def build_multipart_request(uri, image_data, filename, content_type)
+    boundary = "----RubyFormBoundary#{SecureRandom.hex(16)}"
+
+    body = build_multipart_body(boundary, image_data, filename, content_type)
+
+    request = Net::HTTP::Post.new(uri.request_uri)
+    request["Content-Type"] = "multipart/form-data; boundary=#{boundary}"
+    request["Authorization"] = "Bearer #{@api_key}"
+    request["Accept"] = "application/json"
+    request.body = body
+
+    request
+  end
+
+  def build_multipart_body(boundary, image_data, filename, content_type)
+    body = +""
+    body << "--#{boundary}\r\n"
+    body << "Content-Disposition: form-data; name=\"file\"; filename=\"#{filename}\"\r\n"
+    body << "Content-Type: #{content_type}\r\n"
+    body << "\r\n"
+    body << image_data
+    body << "\r\n"
+    body << "--#{boundary}--\r\n"
+    body
+  end
+
+  def execute_request(http, request)
+    http.request(request)
+  rescue Net::OpenTimeout, Net::ReadTimeout => e
+    raise TimeoutError, "API request timed out: #{e.message}"
+  rescue StandardError => e
+    raise RequestError, "API request failed: #{e.message}"
+  end
+
+  def parse_response(response)
+    case response.code.to_i
+    when 200..299
+      JSON.parse(response.body, symbolize_names: true)
+    when 401
+      raise RequestError, "Authentication failed: Invalid API key"
+    when 404
+      raise RequestError, "API endpoint not found"
+    when 429
+      raise RequestError, "Rate limit exceeded"
+    when 500..599
+      raise RequestError, "API server error: #{response.code}"
+    else
+      raise RequestError, "Unexpected response: #{response.code} - #{response.body}"
+    end
+  end
+end

--- a/app/views/images/show.html.erb
+++ b/app/views/images/show.html.erb
@@ -31,5 +31,8 @@
 
 <p>
   <%= link_to "一覧に戻る", images_path %>
+  <% if @image.failed? %>
+    <%= link_to "再試行", retry_image_path(@image), data: { turbo_method: :post } %>
+  <% end %>
   <%= link_to "削除", image_path(@image), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } %>
 </p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,11 @@ Rails.application.routes.draw do
   root "dashboard#index"
 
   # 画像
-  resources :images, only: %i[index show new create destroy]
+  resources :images, only: %i[index show new create destroy] do
+    member do
+      post :retry
+    end
+  end
 
   # 管理者画面
   namespace :admin do

--- a/test/jobs/ocr_process_job_test.rb
+++ b/test/jobs/ocr_process_job_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class OcrProcessJobTest < ActiveJob::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## Summary

- 外部 OCR API と連携するクライアントを実装
- 画像アップロード後に自動で OCR 処理をバックグラウンドで実行
- エラー時のリトライ機能を追加

## 変更内容

- `OcrApiClient` クラス: multipart/form-data で画像を送信
- `OcrProcessJob`: Active Job で非同期処理
- 画像作成時に自動でジョブをキュー
- 失敗した画像の再試行機能
- 環境変数の例 (`.env.example`)

## 環境変数

```
OCR_API_ENDPOINT=https://api.example.com/v1/ocr
OCR_API_KEY=your_api_key_here
OCR_API_TIMEOUT=60
```

## Test plan

- [ ] 環境変数が設定されていない場合、OCR 処理がスキップされる
- [ ] 環境変数を設定した状態で画像をアップロードすると OCR 処理が実行される
- [ ] OCR 処理が完了すると画像のステータスが completed になる
- [ ] OCR 処理が失敗した場合、ステータスが failed になる
- [ ] 失敗した画像の詳細ページで「再試行」ボタンが表示される
- [ ] 再試行ボタンをクリックすると OCR 処理が再実行される

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)