### PR TITLE
結果ダウンロード機能を実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,9 @@ gem "thruster", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 gem "image_processing", "~> 1.2"
 
+# ZIP file generation
+gem "rubyzip"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -518,6 +518,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 8.1.2)
   rubocop-rails-omakase
+  rubyzip
   selenium-webdriver
   solid_cable
   solid_cache

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -1,6 +1,6 @@
 class ImagesController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_image, only: %i[show destroy retry]
+  before_action :set_image, only: %i[show destroy retry download]
 
   def index
     @images = current_user.images.recent.with_attached_file
@@ -50,9 +50,65 @@ class ImagesController < ApplicationController
     end
   end
 
+  def download
+    unless @image.completed? && @image.ocr_result.present?
+      redirect_to image_path(@image), alert: "ダウンロードできる結果がありません。"
+      return
+    end
+
+    format = params[:format] || "txt"
+    content, filename, content_type = generate_download_content(@image, format)
+
+    send_data content, filename: filename, type: content_type, disposition: "attachment"
+  end
+
+  def download_all
+    images = current_user.images.where(status: "completed").where.not(ocr_result: nil)
+
+    if images.empty?
+      redirect_to images_path, alert: "ダウンロードできる結果がありません。"
+      return
+    end
+
+    format = params[:format] || "txt"
+    zip_data = generate_zip(images, format)
+
+    send_data zip_data, filename: "ocr_results_#{Time.current.strftime('%Y%m%d%H%M%S')}.zip",
+                        type: "application/zip", disposition: "attachment"
+  end
+
   private
 
   def set_image
     @image = current_user.images.find(params[:id])
+  end
+
+  def generate_download_content(image, format)
+    base_name = File.basename(image.name, ".*")
+
+    case format
+    when "md", "markdown"
+      content = "# #{image.name}\n\n#{image.ocr_result}"
+      [ content, "#{base_name}.md", "text/markdown" ]
+    when "txt", "text"
+      [ image.ocr_result, "#{base_name}.txt", "text/plain" ]
+    else
+      [ image.ocr_result, "#{base_name}.txt", "text/plain" ]
+    end
+  end
+
+  def generate_zip(images, format)
+    require "zip"
+
+    stringio = Zip::OutputStream.write_buffer do |zio|
+      images.each do |image|
+        content, filename, = generate_download_content(image, format)
+        zio.put_next_entry(filename)
+        zio.write(content)
+      end
+    end
+
+    stringio.rewind
+    stringio.read
   end
 end

--- a/app/views/images/index.html.erb
+++ b/app/views/images/index.html.erb
@@ -1,6 +1,18 @@
 <h1>画像一覧</h1>
 
-<p><%= link_to "新規アップロード", new_image_path %></p>
+<p>
+  <%= link_to "新規アップロード", new_image_path %>
+</p>
+
+<% completed_count = @images.select(&:completed?).count %>
+<% if completed_count > 0 %>
+  <h2>一括ダウンロード</h2>
+  <p>
+    完了した <%= completed_count %> 件の結果をダウンロード:
+    <%= link_to "テキスト形式 (ZIP)", download_all_images_path(format: "txt") %> |
+    <%= link_to "Markdown 形式 (ZIP)", download_all_images_path(format: "md") %>
+  </p>
+<% end %>
 
 <% if @images.any? %>
   <table>
@@ -39,6 +51,9 @@
           <td><%= l(image.created_at, format: :long) %></td>
           <td>
             <%= link_to "詳細", image_path(image) %>
+            <% if image.completed? && image.ocr_result.present? %>
+              <%= link_to "DL", download_image_path(image, format: "txt"), title: "ダウンロード" %>
+            <% end %>
             <%= link_to "削除", image_path(image), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } %>
           </td>
         </tr>

--- a/app/views/images/show.html.erb
+++ b/app/views/images/show.html.erb
@@ -27,6 +27,12 @@
 <% if @image.ocr_result.present? %>
   <h2>OCR 結果</h2>
   <pre><%= @image.ocr_result %></pre>
+
+  <h3>ダウンロード</h3>
+  <ul>
+    <li><%= link_to "テキスト形式 (.txt)", download_image_path(@image, format: "txt") %></li>
+    <li><%= link_to "Markdown 形式 (.md)", download_image_path(@image, format: "md") %></li>
+  </ul>
 <% end %>
 
 <p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,10 @@ Rails.application.routes.draw do
   resources :images, only: %i[index show new create destroy] do
     member do
       post :retry
+      get :download
+    end
+    collection do
+      get :download_all
     end
   end
 


### PR DESCRIPTION
## Summary

- OCR 結果のダウンロード機能を実装
- 単一ファイルおよび複数ファイルの一括ダウンロードに対応
- テキストと Markdown の 2 種類の形式をサポート

## 変更内容

- `download` アクション: 単一ファイルのダウンロード
- `download_all` アクション: 完了した全結果を ZIP でダウンロード
- 対応フォーマット: テキスト (.txt)、Markdown (.md)
- rubyzip gem を追加

## Test plan

- [ ] 完了した画像の詳細ページでダウンロードリンクが表示される
- [ ] テキスト形式でダウンロードできる
- [ ] Markdown 形式でダウンロードできる
- [ ] 画像一覧ページで一括ダウンロードリンクが表示される
- [ ] 一括ダウンロードで ZIP ファイルが取得できる
- [ ] ZIP 内に各画像の OCR 結果が含まれている

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)