### PR TITLE
初回セットアップと IdP 関連のエラーを修正

### DIFF
--- a/app/controllers/admin/identity_providers_controller.rb
+++ b/app/controllers/admin/identity_providers_controller.rb
@@ -45,6 +45,23 @@ module Admin
         notice: "IdP を削除しました。設定を反映するにはアプリを再起動してください。"
     end
 
+    def restart_app
+      if Rails.env.development?
+        # tmp/restart.txt をタッチして再起動をトリガー
+        FileUtils.touch(Rails.root.join("tmp/restart.txt"))
+
+        # Puma を再起動（バックグラウンドで新しいサーバーを起動し、現在のプロセスを終了）
+        pid = spawn("cd #{Rails.root} && sleep 1 && bin/rails server -p 3000", [:out, :err] => "/dev/null")
+        Process.detach(pid)
+
+        # 現在のサーバーを終了
+        Thread.new { sleep 0.5; Process.kill("TERM", Process.pid) }
+      end
+
+      redirect_to admin_identity_providers_path,
+        notice: "アプリを再起動中です。3秒後に自動でリロードします。"
+    end
+
     private
 
     def set_identity_provider

--- a/app/controllers/setup_controller.rb
+++ b/app/controllers/setup_controller.rb
@@ -1,5 +1,6 @@
 class SetupController < ApplicationController
   skip_before_action :require_setup_completed
+  skip_before_action :authenticate_user!
   before_action :redirect_if_setup_completed
 
   def new

--- a/app/models/identity_provider.rb
+++ b/app/models/identity_provider.rb
@@ -25,6 +25,10 @@ class IdentityProvider < ApplicationRecord
     "#{provider_type}_#{slug}".to_sym
   end
 
+  def omniauth_route_available?
+    Devise.omniauth_configs.key?(omniauth_provider_name)
+  end
+
   private
 
   def generate_slug

--- a/app/views/admin/identity_providers/index.html.erb
+++ b/app/views/admin/identity_providers/index.html.erb
@@ -37,5 +37,19 @@
   <p>IdP が登録されていません。</p>
 <% end %>
 
+<% if Rails.env.development? %>
+  <h2>アプリ再起動</h2>
+  <p>IdP の追加・変更を反映するにはアプリの再起動が必要です。</p>
+  <%= button_to "アプリを再起動", restart_app_admin_identity_providers_path, data: { turbo: false, confirm: "アプリを再起動しますか？" } %>
+<% end %>
+
+<% if flash[:notice]&.include?("再起動中") %>
+  <script>
+    setTimeout(function() {
+      location.reload();
+    }, 3000);
+  </script>
+<% end %>
+
 <p><%= link_to "認証設定へ", admin_auth_settings_path %></p>
 <p><%= link_to "ダッシュボードへ戻る", root_path %></p>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -32,10 +32,14 @@
   <ul>
     <% visible_idps.each do |idp| %>
       <li>
-        <%= button_to idp.name,
-            user_omniauth_authorize_path(idp.omniauth_provider_name),
-            method: :post,
-            data: { turbo: false } %>
+        <% if idp.omniauth_route_available? %>
+          <%= button_to idp.name,
+              user_omniauth_authorize_path(idp.omniauth_provider_name),
+              method: :post,
+              data: { turbo: false } %>
+        <% else %>
+          <span><%= idp.name %>（アプリ再起動が必要）</span>
+        <% end %>
       </li>
     <% end %>
   </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   }
 
   # 初回セットアップ
-  resource :setup, only: %i[new create]
+  resource :setup, only: %i[new create], controller: "setup"
 
   # ダッシュボード（ルート）
   root "dashboard#index"
@@ -22,7 +22,11 @@ Rails.application.routes.draw do
 
   # 管理者画面
   namespace :admin do
-    resources :identity_providers
+    resources :identity_providers do
+      collection do
+        post :restart_app
+      end
+    end
     resource :auth_settings, only: %i[show update]
   end
 


### PR DESCRIPTION
## Summary

動作確認中に発見されたエラーを修正

## 修正内容

### #15 SetupController のルーティングエラー
- `resource :setup` が `SetupsController` を探す問題
- `controller: "setup"` を明示的に指定

### #16 SetupController の認証スキップ漏れ
- 初回セットアップ画面でログインループが発生
- `skip_before_action :authenticate_user!` を追加

### #17 IdP 追加後の OmniAuth ルートエラー
- DB に IdP を追加してもアプリ再起動までルートが存在しない
- `omniauth_route_available?` でルートの存在を確認
- ルートがない場合は「アプリ再起動が必要」と表示

### #18 管理画面からのアプリ再起動機能
- 開発環境限定で再起動ボタンを追加
- IdP 変更後の再起動を Web UI から実行可能に

## Test plan

- [ ] 初回アクセスで管理者登録画面が表示される
- [ ] 管理者登録後、ダッシュボードにリダイレクトされる
- [ ] IdP を追加後、ログイン画面で「アプリ再起動が必要」と表示される
- [ ] 管理画面から再起動ボタンをクリックするとアプリが再起動する
- [ ] 再起動後、IdP のログインボタンが有効になる

Closes #15, #16, #17, #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)