### PR TITLE
セルフサインアップ機能を実装

### DIFF
--- a/app/controllers/admin/auth_settings_controller.rb
+++ b/app/controllers/admin/auth_settings_controller.rb
@@ -17,7 +17,7 @@ module Admin
     private
 
     def auth_setting_params
-      params.require(:auth_setting).permit(:local_auth_enabled, :local_auth_show_on_login)
+      params.require(:auth_setting).permit(:local_auth_enabled, :local_auth_show_on_login, :self_signup_enabled)
     end
   end
 end

--- a/app/controllers/admin/identity_providers_controller.rb
+++ b/app/controllers/admin/identity_providers_controller.rb
@@ -51,7 +51,7 @@ module Admin
         FileUtils.touch(Rails.root.join("tmp/restart.txt"))
 
         # Puma を再起動（バックグラウンドで新しいサーバーを起動し、現在のプロセスを終了）
-        pid = spawn("cd #{Rails.root} && sleep 1 && bin/rails server -p 3000", [:out, :err] => "/dev/null")
+        pid = spawn("cd #{Rails.root} && sleep 1 && bin/rails server -p 3000", [ :out, :err ] => "/dev/null")
         Process.detach(pid)
 
         # 現在のサーバーを終了

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,11 @@
+class Users::RegistrationsController < Devise::RegistrationsController
+  before_action :check_self_signup_enabled, only: %i[new create]
+
+  private
+
+  def check_self_signup_enabled
+    unless AuthSetting.self_signup_enabled?
+      redirect_to new_user_session_path, alert: "新規登録は現在無効になっています。"
+    end
+  end
+end

--- a/app/models/auth_setting.rb
+++ b/app/models/auth_setting.rb
@@ -11,4 +11,8 @@ class AuthSetting < ApplicationRecord
   def self.local_auth_show_on_login?
     instance.local_auth_show_on_login
   end
+
+  def self.self_signup_enabled?
+    instance.self_signup_enabled
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable
-  devise :database_authenticatable,
+  devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
          :omniauthable
 

--- a/app/views/admin/auth_settings/show.html.erb
+++ b/app/views/admin/auth_settings/show.html.erb
@@ -24,6 +24,14 @@
     <%= f.check_box :local_auth_show_on_login %>
   </div>
 
+  <h2>セルフサインアップ</h2>
+
+  <div>
+    <%= f.label :self_signup_enabled, "新規登録を許可する" %>
+    <%= f.check_box :self_signup_enabled %>
+    <p><small>有効にすると、ログイン画面から新規ユーザー登録ができるようになります。</small></p>
+  </div>
+
   <h2>外部 IdP</h2>
   <p>
     登録済み IdP: <%= IdentityProvider.count %> 件

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,0 +1,29 @@
+<h2>新規登録</h2>
+
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <div>
+    <%= f.label :email, "メールアドレス" %>
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div>
+    <%= f.label :password, "パスワード" %>
+    <% if @minimum_password_length %>
+      <em>（<%= @minimum_password_length %>文字以上）</em>
+    <% end %>
+    <%= f.password_field :password, autocomplete: "new-password" %>
+  </div>
+
+  <div>
+    <%= f.label :password_confirmation, "パスワード（確認）" %>
+    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+  </div>
+
+  <div>
+    <%= f.submit "登録" %>
+  </div>
+<% end %>
+
+<p><%= link_to "ログインはこちら", new_user_session_path %></p>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -48,3 +48,7 @@
 <% unless AuthSetting.local_auth_show_on_login? || visible_idps.any? %>
   <p>利用可能なログイン方法がありません。管理者に連絡してください。</p>
 <% end %>
+
+<% if AuthSetting.self_signup_enabled? %>
+  <p><%= link_to "アカウントをお持ちでない方はこちら", new_user_registration_path %></p>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: {
-    omniauth_callbacks: "users/omniauth_callbacks"
+    omniauth_callbacks: "users/omniauth_callbacks",
+    registrations: "users/registrations"
   }
 
   # 初回セットアップ

--- a/db/migrate/20260317115903_add_self_signup_to_auth_settings.rb
+++ b/db/migrate/20260317115903_add_self_signup_to_auth_settings.rb
@@ -1,0 +1,5 @@
+class AddSelfSignupToAuthSettings < ActiveRecord::Migration[8.1]
+  def change
+    add_column :auth_settings, :self_signup_enabled, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_17_074913) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_17_115903) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -43,6 +43,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_17_074913) do
     t.datetime "created_at", null: false
     t.boolean "local_auth_enabled", default: true, null: false
     t.boolean "local_auth_show_on_login", default: true, null: false
+    t.boolean "self_signup_enabled", default: false, null: false
     t.datetime "updated_at", null: false
   end
 


### PR DESCRIPTION
## Summary

ユーザーが自分でアカウントを登録できる機能を実装

## 変更内容

### ローカル認証の新規登録
- Devise の `:registerable` モジュールを有効化
- カスタム `RegistrationsController` で設定を確認
- 登録画面（`/users/sign_up`）を作成
- ログイン画面に登録リンクを追加（設定有効時のみ）

### 管理機能
- `AuthSetting` に `self_signup_enabled` 設定を追加
- 管理画面（`/admin/auth_settings`）でセルフサインアップの有効/無効を設定可能

### SAML/OIDC
- 既存の `User.from_omniauth` で `first_or_create` を使用しており、新規ユーザーは自動作成される（変更なし）

## Test plan

- [ ] 管理画面で「新規登録を許可する」を有効にする
- [ ] ログイン画面に「アカウントをお持ちでない方はこちら」リンクが表示される
- [ ] 登録画面でメールアドレスとパスワードを入力して登録できる
- [ ] 登録後、ダッシュボードにリダイレクトされる
- [ ] 「新規登録を許可する」を無効にすると、登録リンクが非表示になる
- [ ] 無効時に直接 `/users/sign_up` にアクセスすると、ログイン画面にリダイレクトされる

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)