### PR TITLE
SAML IdP メタデータから設定を自動入力する機能を追加

### DIFF
--- a/app/controllers/admin/identity_providers_controller.rb
+++ b/app/controllers/admin/identity_providers_controller.rb
@@ -45,6 +45,22 @@ module Admin
         notice: "IdP を削除しました。設定を反映するにはアプリを再起動してください。"
     end
 
+    def parse_saml_metadata
+      result = if params[:metadata_file].present?
+        SamlMetadataParser.parse_xml(params[:metadata_file].read)
+      elsif params[:metadata_url].present?
+        SamlMetadataParser.fetch_and_parse(params[:metadata_url])
+      else
+        SamlMetadataParser::Result.new(success?: false, error: "メタデータファイルまたは URL を指定してください")
+      end
+
+      if result.success?
+        render json: { success: true, data: result.data }
+      else
+        render json: { success: false, error: result.error }, status: :unprocessable_entity
+      end
+    end
+
     def restart_app
       if Rails.env.development?
         # tmp/restart.txt をタッチして再起動をトリガー

--- a/app/javascript/controllers/saml_metadata_controller.js
+++ b/app/javascript/controllers/saml_metadata_controller.js
@@ -1,0 +1,97 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["file", "fileButton", "url", "status", "statusMessage"]
+
+  fileSelected() {
+    const hasFile = this.fileTarget.files.length > 0
+    this.fileButtonTarget.disabled = !hasFile
+  }
+
+  async uploadFile() {
+    const file = this.fileTarget.files[0]
+    if (!file) return
+
+    this.showStatus("読み込み中...", "info")
+
+    const formData = new FormData()
+    formData.append("metadata_file", file)
+
+    await this.sendRequest(formData)
+  }
+
+  async fetchUrl() {
+    const url = this.urlTarget.value.trim()
+    if (!url) {
+      this.showStatus("URL を入力してください", "warning")
+      return
+    }
+
+    this.showStatus("取得中...", "info")
+
+    const formData = new FormData()
+    formData.append("metadata_url", url)
+
+    await this.sendRequest(formData)
+  }
+
+  async sendRequest(formData) {
+    try {
+      const response = await fetch("/admin/identity_providers/parse_saml_metadata", {
+        method: "POST",
+        body: formData,
+        headers: {
+          "X-CSRF-Token": document.querySelector('meta[name="csrf-token"]').content,
+          "Accept": "application/json"
+        }
+      })
+
+      const result = await response.json()
+
+      if (result.success) {
+        this.fillForm(result.data)
+        this.showStatus("メタデータを読み込みました", "success")
+      } else {
+        this.showStatus(result.error, "danger")
+      }
+    } catch (error) {
+      this.showStatus("エラーが発生しました: " + error.message, "danger")
+    }
+  }
+
+  fillForm(data) {
+    if (data.name) {
+      const nameField = document.getElementById("identity_provider_name")
+      if (nameField && !nameField.value) {
+        nameField.value = data.name
+      }
+    }
+
+    if (data.idp_sso_url) {
+      const ssoField = document.getElementById("settings_idp_sso_url")
+      if (ssoField) ssoField.value = data.idp_sso_url
+    }
+
+    if (data.idp_slo_url) {
+      const sloField = document.getElementById("settings_idp_slo_url")
+      if (sloField) sloField.value = data.idp_slo_url
+    }
+
+    if (data.idp_cert) {
+      const certField = document.getElementById("settings_idp_cert")
+      if (certField) certField.value = data.idp_cert
+    }
+
+    if (data.entity_id) {
+      const entityIdField = document.getElementById("settings_sp_entity_id")
+      // SP entity ID はそのまま使うかどうか判断が必要なので、参考情報としてログに出力
+      console.log("IdP Entity ID:", data.entity_id)
+    }
+  }
+
+  showStatus(message, type) {
+    this.statusTarget.classList.remove("d-none")
+    this.statusMessageTarget.textContent = message
+    this.statusMessageTarget.className = `alert alert-${type} mb-0 py-2`
+  }
+}

--- a/app/services/saml_metadata_parser.rb
+++ b/app/services/saml_metadata_parser.rb
@@ -1,0 +1,157 @@
+require "nokogiri"
+require "net/http"
+require "uri"
+
+class SamlMetadataParser
+  SAML_NAMESPACES = {
+    "md" => "urn:oasis:names:tc:SAML:2.0:metadata",
+    "ds" => "http://www.w3.org/2000/09/xmldsig#"
+  }.freeze
+
+  Result = Struct.new(:success?, :data, :error, keyword_init: true)
+
+  class << self
+    def parse_xml(xml_content)
+      new.parse_xml(xml_content)
+    end
+
+    def fetch_and_parse(url)
+      new.fetch_and_parse(url)
+    end
+  end
+
+  def parse_xml(xml_content)
+    return Result.new(success?: false, error: "XML が空です") if xml_content.blank?
+
+    doc = Nokogiri::XML(xml_content)
+    doc.remove_namespaces! if doc.namespaces.any?
+
+    entity_descriptor = doc.at_xpath("//EntityDescriptor") || doc.at_xpath("//md:EntityDescriptor", SAML_NAMESPACES)
+    return Result.new(success?: false, error: "EntityDescriptor が見つかりません") unless entity_descriptor
+
+    idp_descriptor = entity_descriptor.at_xpath(".//IDPSSODescriptor") ||
+                     entity_descriptor.at_xpath(".//md:IDPSSODescriptor", SAML_NAMESPACES)
+    return Result.new(success?: false, error: "IDPSSODescriptor が見つかりません") unless idp_descriptor
+
+    data = {
+      entity_id: extract_entity_id(entity_descriptor),
+      idp_sso_url: extract_sso_url(idp_descriptor),
+      idp_slo_url: extract_slo_url(idp_descriptor),
+      idp_cert: extract_certificate(idp_descriptor),
+      name: extract_name(entity_descriptor)
+    }
+
+    Result.new(success?: true, data: data)
+  rescue Nokogiri::XML::SyntaxError => e
+    Result.new(success?: false, error: "XML パースエラー: #{e.message}")
+  rescue StandardError => e
+    Result.new(success?: false, error: "予期しないエラー: #{e.message}")
+  end
+
+  def fetch_and_parse(url)
+    return Result.new(success?: false, error: "URL が空です") if url.blank?
+
+    uri = URI.parse(url)
+    return Result.new(success?: false, error: "無効な URL です") unless uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
+
+    response = fetch_url(uri)
+    return Result.new(success?: false, error: "メタデータの取得に失敗しました: HTTP #{response.code}") unless response.is_a?(Net::HTTPSuccess)
+
+    parse_xml(response.body)
+  rescue URI::InvalidURIError
+    Result.new(success?: false, error: "無効な URL 形式です")
+  rescue Net::OpenTimeout, Net::ReadTimeout
+    Result.new(success?: false, error: "タイムアウトしました")
+  rescue SocketError, Errno::ECONNREFUSED => e
+    Result.new(success?: false, error: "接続できませんでした: #{e.message}")
+  rescue StandardError => e
+    Result.new(success?: false, error: "予期しないエラー: #{e.message}")
+  end
+
+  private
+
+  def fetch_url(uri, redirect_limit = 5)
+    raise "リダイレクト回数が上限を超えました" if redirect_limit == 0
+
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = (uri.scheme == "https")
+    http.open_timeout = 10
+    http.read_timeout = 30
+
+    request = Net::HTTP::Get.new(uri)
+    request["User-Agent"] = "kulip/1.0"
+    request["Accept"] = "application/xml, text/xml"
+
+    response = http.request(request)
+
+    if response.is_a?(Net::HTTPRedirection)
+      new_uri = URI.parse(response["location"])
+      new_uri = URI.join(uri, new_uri) unless new_uri.host
+      return fetch_url(new_uri, redirect_limit - 1)
+    end
+
+    response
+  end
+
+  def extract_entity_id(entity_descriptor)
+    entity_descriptor["entityID"]
+  end
+
+  def extract_sso_url(idp_descriptor)
+    sso_service = idp_descriptor.at_xpath(
+      ".//SingleSignOnService[@Binding='urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect']"
+    ) || idp_descriptor.at_xpath(
+      ".//SingleSignOnService[@Binding='urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST']"
+    ) || idp_descriptor.at_xpath(".//SingleSignOnService")
+
+    sso_service&.[]("Location")
+  end
+
+  def extract_slo_url(idp_descriptor)
+    slo_service = idp_descriptor.at_xpath(
+      ".//SingleLogoutService[@Binding='urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect']"
+    ) || idp_descriptor.at_xpath(
+      ".//SingleLogoutService[@Binding='urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST']"
+    ) || idp_descriptor.at_xpath(".//SingleLogoutService")
+
+    slo_service&.[]("Location")
+  end
+
+  def extract_certificate(idp_descriptor)
+    cert_node = idp_descriptor.at_xpath(".//KeyDescriptor[@use='signing']//X509Certificate") ||
+                idp_descriptor.at_xpath(".//KeyDescriptor//X509Certificate") ||
+                idp_descriptor.at_xpath(".//X509Certificate")
+
+    return nil unless cert_node
+
+    cert_text = cert_node.text.strip.gsub(/\s+/, "")
+    format_certificate(cert_text)
+  end
+
+  def format_certificate(cert_text)
+    return nil if cert_text.blank?
+
+    lines = cert_text.scan(/.{1,64}/)
+    "-----BEGIN CERTIFICATE-----\n#{lines.join("\n")}\n-----END CERTIFICATE-----"
+  end
+
+  def extract_name(entity_descriptor)
+    # Organization の DisplayName を優先
+    org_name = entity_descriptor.at_xpath(".//Organization/OrganizationDisplayName")&.text ||
+               entity_descriptor.at_xpath(".//Organization/OrganizationName")&.text
+
+    return org_name if org_name.present?
+
+    # entityID からドメイン部分を抽出
+    entity_id = entity_descriptor["entityID"]
+    return nil unless entity_id
+
+    if entity_id.start_with?("http")
+      URI.parse(entity_id).host
+    else
+      entity_id.split("/").first
+    end
+  rescue URI::InvalidURIError
+    nil
+  end
+end

--- a/app/views/admin/identity_providers/_form.html.erb
+++ b/app/views/admin/identity_providers/_form.html.erb
@@ -38,6 +38,47 @@
   <h6 class="text-muted mb-3"><%= @identity_provider.provider_type&.upcase %> 設定</h6>
 
   <% if @identity_provider.provider_type == "saml" %>
+    <% if @identity_provider.new_record? %>
+      <div class="card bg-light mb-4" data-controller="saml-metadata">
+        <div class="card-body">
+          <h6 class="card-title">IdP メタデータから自動入力</h6>
+          <p class="card-text small text-muted">IdP のメタデータ XML をアップロードするか、URL を指定して設定を自動入力できます。</p>
+
+          <ul class="nav nav-tabs mb-3" role="tablist">
+            <li class="nav-item" role="presentation">
+              <button class="nav-link active" id="metadata-file-tab" data-bs-toggle="tab" data-bs-target="#metadata-file" type="button" role="tab">ファイル</button>
+            </li>
+            <li class="nav-item" role="presentation">
+              <button class="nav-link" id="metadata-url-tab" data-bs-toggle="tab" data-bs-target="#metadata-url" type="button" role="tab">URL</button>
+            </li>
+          </ul>
+
+          <div class="tab-content">
+            <div class="tab-pane fade show active" id="metadata-file" role="tabpanel">
+              <div class="input-group">
+                <input type="file" class="form-control" id="metadata_file" accept=".xml,application/xml,text/xml" data-saml-metadata-target="file" data-action="change->saml-metadata#fileSelected">
+                <button type="button" class="btn btn-outline-primary" data-action="click->saml-metadata#uploadFile" data-saml-metadata-target="fileButton" disabled>
+                  読み込む
+                </button>
+              </div>
+            </div>
+            <div class="tab-pane fade" id="metadata-url" role="tabpanel">
+              <div class="input-group">
+                <input type="url" class="form-control" id="metadata_url" placeholder="https://idp.example.com/metadata" data-saml-metadata-target="url">
+                <button type="button" class="btn btn-outline-primary" data-action="click->saml-metadata#fetchUrl">
+                  取得
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <div class="mt-2 d-none" data-saml-metadata-target="status">
+            <div class="alert alert-info mb-0 py-2" data-saml-metadata-target="statusMessage"></div>
+          </div>
+        </div>
+      </div>
+    <% end %>
+
     <div class="mb-3">
       <%= label_tag "settings_idp_sso_url", "IdP SSO URL", class: "form-label" %>
       <%= text_field_tag "identity_provider[settings][idp_sso_url]",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
     resources :identity_providers do
       collection do
         post :restart_app
+        post :parse_saml_metadata
       end
     end
     resource :settings, only: [ :show ] do

--- a/test/controllers/admin/identity_providers_controller_test.rb
+++ b/test/controllers/admin/identity_providers_controller_test.rb
@@ -1,0 +1,102 @@
+require "test_helper"
+
+module Admin
+  class IdentityProvidersControllerTest < ActionDispatch::IntegrationTest
+    VALID_SAML_METADATA = <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata"
+                        entityID="https://idp.example.com/metadata">
+        <IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+          <KeyDescriptor use="signing">
+            <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+              <ds:X509Data>
+                <ds:X509Certificate>MIICjDCCAXSgAwIBAgIGAY0test</ds:X509Certificate>
+              </ds:X509Data>
+            </ds:KeyInfo>
+          </KeyDescriptor>
+          <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+                               Location="https://idp.example.com/slo"/>
+          <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+                               Location="https://idp.example.com/sso"/>
+        </IDPSSODescriptor>
+        <Organization>
+          <OrganizationDisplayName xml:lang="en">Example IdP</OrganizationDisplayName>
+        </Organization>
+      </EntityDescriptor>
+    XML
+
+    setup do
+      @admin = users(:admin)
+      @user = users(:user)
+    end
+
+    test "parse_saml_metadata は認証が必要" do
+      post parse_saml_metadata_admin_identity_providers_path
+      assert_redirected_to new_user_session_path
+    end
+
+    test "parse_saml_metadata は管理者権限が必要" do
+      sign_in @user
+      post parse_saml_metadata_admin_identity_providers_path
+      assert_redirected_to root_path
+    end
+
+    test "parse_saml_metadata はファイルアップロードで SAML メタデータをパースする" do
+      sign_in @admin
+
+      file = Rack::Test::UploadedFile.new(
+        StringIO.new(VALID_SAML_METADATA),
+        "application/xml",
+        original_filename: "metadata.xml"
+      )
+
+      post parse_saml_metadata_admin_identity_providers_path, params: { metadata_file: file }
+
+      assert_response :success
+      json = JSON.parse(response.body)
+      assert json["success"]
+      assert_equal "https://idp.example.com/sso", json["data"]["idp_sso_url"]
+      assert_equal "https://idp.example.com/slo", json["data"]["idp_slo_url"]
+      assert_equal "https://idp.example.com/metadata", json["data"]["entity_id"]
+      assert_equal "Example IdP", json["data"]["name"]
+    end
+
+    test "parse_saml_metadata はファイルも URL も指定されていない場合エラーを返す" do
+      sign_in @admin
+
+      post parse_saml_metadata_admin_identity_providers_path
+
+      assert_response :unprocessable_entity
+      json = JSON.parse(response.body)
+      assert_not json["success"]
+      assert_equal "メタデータファイルまたは URL を指定してください", json["error"]
+    end
+
+    test "parse_saml_metadata は無効な XML でエラーを返す" do
+      sign_in @admin
+
+      file = Rack::Test::UploadedFile.new(
+        StringIO.new("<invalid>xml</invalid>"),
+        "application/xml",
+        original_filename: "invalid.xml"
+      )
+
+      post parse_saml_metadata_admin_identity_providers_path, params: { metadata_file: file }
+
+      assert_response :unprocessable_entity
+      json = JSON.parse(response.body)
+      assert_not json["success"]
+    end
+
+    test "parse_saml_metadata は無効な URL でエラーを返す" do
+      sign_in @admin
+
+      post parse_saml_metadata_admin_identity_providers_path, params: { metadata_url: "not-a-url" }
+
+      assert_response :unprocessable_entity
+      json = JSON.parse(response.body)
+      assert_not json["success"]
+      assert_equal "無効な URL です", json["error"]
+    end
+  end
+end

--- a/test/services/saml_metadata_parser_test.rb
+++ b/test/services/saml_metadata_parser_test.rb
@@ -1,0 +1,121 @@
+require "test_helper"
+
+class SamlMetadataParserTest < ActiveSupport::TestCase
+  VALID_METADATA = <<~XML
+    <?xml version="1.0" encoding="UTF-8"?>
+    <EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata"
+                      entityID="https://idp.example.com/metadata">
+      <IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+        <KeyDescriptor use="signing">
+          <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+            <ds:X509Data>
+              <ds:X509Certificate>MIICjDCCAXSgAwIBAgIGAY0test</ds:X509Certificate>
+            </ds:X509Data>
+          </ds:KeyInfo>
+        </KeyDescriptor>
+        <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+                             Location="https://idp.example.com/slo"/>
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+                             Location="https://idp.example.com/sso"/>
+      </IDPSSODescriptor>
+      <Organization>
+        <OrganizationName xml:lang="en">Example IdP</OrganizationName>
+        <OrganizationDisplayName xml:lang="en">Example Identity Provider</OrganizationDisplayName>
+      </Organization>
+    </EntityDescriptor>
+  XML
+
+  test "parse_xml は有効なメタデータを正しくパースする" do
+    result = SamlMetadataParser.parse_xml(VALID_METADATA)
+
+    assert result.success?
+    assert_equal "https://idp.example.com/metadata", result.data[:entity_id]
+    assert_equal "https://idp.example.com/sso", result.data[:idp_sso_url]
+    assert_equal "https://idp.example.com/slo", result.data[:idp_slo_url]
+    assert_includes result.data[:idp_cert], "BEGIN CERTIFICATE"
+    assert_includes result.data[:idp_cert], "END CERTIFICATE"
+    assert_equal "Example Identity Provider", result.data[:name]
+  end
+
+  test "parse_xml は空の XML でエラーを返す" do
+    result = SamlMetadataParser.parse_xml("")
+
+    assert_not result.success?
+    assert_equal "XML が空です", result.error
+  end
+
+  test "parse_xml は nil でエラーを返す" do
+    result = SamlMetadataParser.parse_xml(nil)
+
+    assert_not result.success?
+    assert_equal "XML が空です", result.error
+  end
+
+  test "parse_xml は EntityDescriptor がない XML でエラーを返す" do
+    xml = "<root><child>test</child></root>"
+    result = SamlMetadataParser.parse_xml(xml)
+
+    assert_not result.success?
+    assert_equal "EntityDescriptor が見つかりません", result.error
+  end
+
+  test "parse_xml は IDPSSODescriptor がない XML でエラーを返す" do
+    xml = <<~XML
+      <?xml version="1.0"?>
+      <EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" entityID="test">
+      </EntityDescriptor>
+    XML
+    result = SamlMetadataParser.parse_xml(xml)
+
+    assert_not result.success?
+    assert_equal "IDPSSODescriptor が見つかりません", result.error
+  end
+
+  test "parse_xml は不正な XML でエラーを返す" do
+    xml = "これは XML ではない"
+    result = SamlMetadataParser.parse_xml(xml)
+
+    # nokogiri は不正なXMLでもパースを試みるが、EntityDescriptor がないのでエラーになる
+    assert_not result.success?
+  end
+
+  test "fetch_and_parse は空の URL でエラーを返す" do
+    result = SamlMetadataParser.fetch_and_parse("")
+
+    assert_not result.success?
+    assert_equal "URL が空です", result.error
+  end
+
+  test "fetch_and_parse は無効な URL 形式でエラーを返す" do
+    result = SamlMetadataParser.fetch_and_parse("not-a-url")
+
+    assert_not result.success?
+    assert_equal "無効な URL です", result.error
+  end
+
+  test "parse_xml は HTTP-POST バインディングの SSO URL も抽出する" do
+    xml = <<~XML
+      <?xml version="1.0"?>
+      <EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" entityID="test">
+        <IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+          <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+                               Location="https://idp.example.com/sso-post"/>
+        </IDPSSODescriptor>
+      </EntityDescriptor>
+    XML
+
+    result = SamlMetadataParser.parse_xml(xml)
+
+    assert result.success?
+    assert_equal "https://idp.example.com/sso-post", result.data[:idp_sso_url]
+  end
+
+  test "parse_xml は証明書を正しい PEM 形式にフォーマットする" do
+    result = SamlMetadataParser.parse_xml(VALID_METADATA)
+
+    assert result.success?
+    cert = result.data[:idp_cert]
+    assert_match(/\A-----BEGIN CERTIFICATE-----\n/, cert)
+    assert_match(/\n-----END CERTIFICATE-----\z/, cert)
+  end
+end


### PR DESCRIPTION
## Summary

- SAML IdP 新規作成画面で、メタデータ XML を読み込んで設定項目を自動入力する機能を追加
- ファイルアップロードと URL 取得の両方に対応
- サーバーサイド（nokogiri）で XML をパース

## 変更内容

- `SamlMetadataParser` サービスを作成（XML パース、URL 取得対応）
- コントローラに `parse_saml_metadata` アクションを追加
- ビューにメタデータ入力 UI（ファイル/URL タブ切り替え）を追加
- Stimulus コントローラでフォーム自動入力を実装

## Test plan

- [x] サービステスト（16 テスト、49 アサーション）
- [x] コントローラテスト
- [x] 手動動作確認済み

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)