### PR TITLE
管理者設定画面から SMTP サーバ設定を行えるようにする

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -6,6 +6,7 @@ module Admin
       @quota_form = Forms::QuotaSettingsForm.new
       @retention_form = Forms::RetentionSettingsForm.new
       @notification_form = Forms::NotificationSettingsForm.new
+      @smtp_form = Forms::SmtpSettingsForm.new
     end
 
     def update_auth
@@ -63,6 +64,17 @@ module Admin
       end
     end
 
+    def update_smtp
+      @smtp_form = Forms::SmtpSettingsForm.new(smtp_settings_params)
+
+      if @smtp_form.save
+        redirect_to admin_settings_path(anchor: "smtp"), notice: "送信メールサーバ設定を更新しました。"
+      else
+        load_other_forms
+        render :show, status: :unprocessable_entity
+      end
+    end
+
     private
 
     def load_other_forms
@@ -71,6 +83,7 @@ module Admin
       @quota_form ||= Forms::QuotaSettingsForm.new
       @retention_form ||= Forms::RetentionSettingsForm.new
       @notification_form ||= Forms::NotificationSettingsForm.new
+      @smtp_form ||= Forms::SmtpSettingsForm.new
     end
 
     def auth_settings_params
@@ -91,6 +104,13 @@ module Admin
 
     def notification_settings_params
       params.require(:notification_settings).permit(:enabled, :subject, :body)
+    end
+
+    def smtp_settings_params
+      params.require(:smtp_settings).permit(
+        :enabled, :address, :port, :authentication,
+        :user_name, :password, :enable_starttls, :from_address
+      )
     end
   end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,15 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "from@example.com"
   layout "mailer"
+
+  default from: -> { Setting.smtp_from_address.presence || "noreply@example.com" }
+
+  before_action :configure_smtp_settings
+
+  private
+
+  def configure_smtp_settings
+    return unless Setting.smtp_configured?
+
+    mail.delivery_method.settings.merge!(Setting.smtp_settings)
+  end
 end

--- a/app/models/forms/smtp_settings_form.rb
+++ b/app/models/forms/smtp_settings_form.rb
@@ -1,0 +1,72 @@
+module Forms
+  class SmtpSettingsForm
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    AUTHENTICATION_OPTIONS = %w[plain login cram_md5 none].freeze
+
+    attribute :enabled, :boolean
+    attribute :address, :string
+    attribute :port, :integer
+    attribute :authentication, :string
+    attribute :user_name, :string
+    attribute :password, :string
+    attribute :enable_starttls, :boolean
+    attribute :from_address, :string
+
+    validates :address, presence: true, if: :enabled
+    validates :port, numericality: { only_integer: true, greater_than: 0, less_than: 65536 }, if: :enabled
+    validates :authentication, inclusion: { in: AUTHENTICATION_OPTIONS }, allow_blank: true
+    validates :from_address, format: { with: URI::MailTo::EMAIL_REGEXP }, allow_blank: true
+
+    def initialize(attributes = {})
+      super
+      load_from_settings if attributes.empty?
+    end
+
+    def save
+      return false unless valid?
+
+      Setting.smtp_enabled = enabled || false
+      Setting.smtp_address = address.presence || ""
+      Setting.smtp_port = port.presence || 587
+      Setting.smtp_authentication = authentication.presence || "plain"
+      Setting.smtp_user_name = user_name.presence || ""
+      Setting.smtp_password = password.presence || "" if password.present? || !enabled
+      Setting.smtp_enable_starttls = enable_starttls.nil? ? true : enable_starttls
+      Setting.smtp_from_address = from_address.presence || ""
+      true
+    rescue => e
+      errors.add(:base, e.message)
+      false
+    end
+
+    def persisted?
+      true
+    end
+
+    def to_key
+      [ :smtp_settings ]
+    end
+
+    def model_name
+      ActiveModel::Name.new(self, nil, "SmtpSettings")
+    end
+
+    def password_configured?
+      Setting.smtp_password.present?
+    end
+
+    private
+
+    def load_from_settings
+      self.enabled = Setting.smtp_enabled
+      self.address = Setting.smtp_address
+      self.port = Setting.smtp_port.presence || 587
+      self.authentication = Setting.smtp_authentication.presence || "plain"
+      self.user_name = Setting.smtp_user_name
+      self.enable_starttls = Setting.smtp_enable_starttls
+      self.from_address = Setting.smtp_from_address
+    end
+  end
+end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -58,6 +58,16 @@ class Setting < RailsSettings::Base
   field :notification_email_subject, type: :string, default: ""
   field :notification_email_body, type: :string, default: ""
 
+  # === SMTP設定 ===
+  field :smtp_enabled, type: :boolean, default: false
+  field :smtp_address, type: :string, default: ""
+  field :smtp_port, type: :integer, default: 587
+  field :smtp_authentication, type: :string, default: "plain"
+  field :smtp_user_name, type: :string, default: ""
+  field :smtp_password, type: :string, default: ""
+  field :smtp_enable_starttls, type: :boolean, default: true
+  field :smtp_from_address, type: :string, default: ""
+
   # === 互換性メソッド ===
   class << self
     # 認証設定
@@ -122,6 +132,33 @@ class Setting < RailsSettings::Base
 
     def effective_notification_body
       notification_email_body.presence || DEFAULT_NOTIFICATION_BODY
+    end
+
+    # SMTP設定
+    def smtp_enabled?
+      smtp_enabled
+    end
+
+    def smtp_configured?
+      smtp_enabled && smtp_address.present?
+    end
+
+    def smtp_settings
+      return {} unless smtp_configured?
+
+      settings = {
+        address: smtp_address,
+        port: smtp_port,
+        enable_starttls_auto: smtp_enable_starttls
+      }
+
+      if smtp_authentication.present? && smtp_authentication != "none"
+        settings[:authentication] = smtp_authentication.to_sym
+        settings[:user_name] = smtp_user_name if smtp_user_name.present?
+        settings[:password] = smtp_password if smtp_password.present?
+      end
+
+      settings
     end
   end
 end

--- a/app/views/admin/settings/show.html.erb
+++ b/app/views/admin/settings/show.html.erb
@@ -245,3 +245,84 @@
     <% end %>
   </div>
 </div>
+
+<%# 送信メールサーバ設定 %>
+<div class="card mb-4" id="smtp">
+  <div class="card-header d-flex justify-content-between align-items-center">
+    <span>送信メールサーバ</span>
+    <% if Setting.smtp_configured? %>
+      <span class="badge bg-success">設定済み</span>
+    <% else %>
+      <span class="badge bg-secondary">未設定</span>
+    <% end %>
+  </div>
+  <div class="card-body">
+    <%= form_with model: @smtp_form, url: update_smtp_admin_settings_path, method: :patch do |f| %>
+      <% if @smtp_form.errors.any? %>
+        <div class="alert alert-danger">
+          <ul class="mb-0">
+            <% @smtp_form.errors.full_messages.each do |message| %>
+              <li><%= message %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+
+      <div class="form-check mb-3">
+        <%= f.check_box :enabled, class: "form-check-input" %>
+        <%= f.label :enabled, "SMTP 送信を有効にする", class: "form-check-label" %>
+      </div>
+
+      <h6 class="text-muted mb-3">サーバ設定</h6>
+      <div class="row">
+        <div class="col-md-8 mb-3">
+          <%= f.label :address, "SMTP サーバアドレス", class: "form-label" %>
+          <%= f.text_field :address, class: "form-control", placeholder: "例: smtp.example.com" %>
+        </div>
+        <div class="col-md-4 mb-3">
+          <%= f.label :port, "ポート番号", class: "form-label" %>
+          <%= f.number_field :port, class: "form-control", min: 1, max: 65535, placeholder: "587" %>
+        </div>
+      </div>
+
+      <div class="form-check mb-3">
+        <%= f.check_box :enable_starttls, class: "form-check-input" %>
+        <%= f.label :enable_starttls, "STARTTLS を使用する", class: "form-check-label" %>
+      </div>
+
+      <h6 class="text-muted mt-4 mb-3">認証設定</h6>
+      <div class="mb-3">
+        <%= f.label :authentication, "認証方式", class: "form-label" %>
+        <%= f.select :authentication,
+            [["Plain", "plain"], ["Login", "login"], ["CRAM-MD5", "cram_md5"], ["認証なし", "none"]],
+            {},
+            class: "form-select", style: "max-width: 200px;" %>
+      </div>
+
+      <div class="mb-3">
+        <%= f.label :user_name, "ユーザー名", class: "form-label" %>
+        <%= f.text_field :user_name, class: "form-control", autocomplete: "off" %>
+      </div>
+
+      <div class="mb-3">
+        <%= f.label :password, "パスワード", class: "form-label" %>
+        <%= f.password_field :password, class: "form-control", autocomplete: "new-password",
+            placeholder: @smtp_form.password_configured? ? "（設定済み - 変更する場合のみ入力）" : "" %>
+        <% if @smtp_form.password_configured? %>
+          <div class="form-text">パスワードは設定済みです。変更する場合のみ入力してください。</div>
+        <% end %>
+      </div>
+
+      <h6 class="text-muted mt-4 mb-3">送信設定</h6>
+      <div class="mb-3">
+        <%= f.label :from_address, "送信元メールアドレス", class: "form-label" %>
+        <%= f.email_field :from_address, class: "form-control", placeholder: "例: noreply@example.com" %>
+        <div class="form-text">メール送信時の From アドレス</div>
+      </div>
+
+      <div class="d-grid gap-2 d-md-flex justify-content-md-end">
+        <%= f.submit "保存", class: "btn btn-primary" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@ Rails.application.routes.draw do
       patch :update_quota, on: :member
       patch :update_retention, on: :member
       patch :update_notification, on: :member
+      patch :update_smtp, on: :member
     end
     resources :users, only: %i[index] do
       member do

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -35,6 +35,7 @@ module Admin
       assert_select "#quota"
       assert_select "#retention"
       assert_select "#notification"
+      assert_select "#smtp"
     end
 
     # Auth settings tests
@@ -178,6 +179,77 @@ module Admin
 
       patch update_notification_admin_settings_path, params: {
         notification_settings: { enabled: true }
+      }
+
+      assert_redirected_to root_path
+    end
+
+    # SMTP settings tests
+    test "update_smtp enables smtp" do
+      sign_in @admin
+      Setting.smtp_enabled = false
+
+      patch update_smtp_admin_settings_path, params: {
+        smtp_settings: {
+          enabled: true,
+          address: "smtp.example.com",
+          port: 587,
+          authentication: "plain",
+          user_name: "user@example.com",
+          password: "secret",
+          enable_starttls: true,
+          from_address: "noreply@example.com"
+        }
+      }
+
+      assert_redirected_to admin_settings_path(anchor: "smtp")
+      assert Setting.smtp_enabled?
+      assert_equal "smtp.example.com", Setting.smtp_address
+      assert_equal 587, Setting.smtp_port
+      assert_equal "plain", Setting.smtp_authentication
+      assert_equal "user@example.com", Setting.smtp_user_name
+      assert_equal "secret", Setting.smtp_password
+      assert Setting.smtp_enable_starttls
+      assert_equal "noreply@example.com", Setting.smtp_from_address
+    end
+
+    test "update_smtp disables smtp" do
+      sign_in @admin
+      Setting.smtp_enabled = true
+
+      patch update_smtp_admin_settings_path, params: {
+        smtp_settings: { enabled: false }
+      }
+
+      assert_redirected_to admin_settings_path(anchor: "smtp")
+      assert_not Setting.smtp_enabled?
+    end
+
+    test "update_smtp validates address when enabled" do
+      sign_in @admin
+
+      patch update_smtp_admin_settings_path, params: {
+        smtp_settings: { enabled: true, address: "" }
+      }
+
+      assert_response :unprocessable_entity
+    end
+
+    test "update_smtp validates port number" do
+      sign_in @admin
+
+      patch update_smtp_admin_settings_path, params: {
+        smtp_settings: { enabled: true, address: "smtp.example.com", port: 99999 }
+      }
+
+      assert_response :unprocessable_entity
+    end
+
+    test "update_smtp requires admin" do
+      sign_in @user
+
+      patch update_smtp_admin_settings_path, params: {
+        smtp_settings: { enabled: true }
       }
 
       assert_redirected_to root_path


### PR DESCRIPTION
## Summary

- 管理者設定画面（`/admin/settings`）に「送信メールサーバ」セクションを追加
- SMTP サーバの設定を Web UI から動的に変更可能に
- 設定値は `rails-settings-cached` で管理

## 変更内容

### 設定項目
- SMTP サーバアドレス
- ポート番号
- 認証方式（Plain / Login / CRAM-MD5 / 認証なし）
- ユーザー名 / パスワード
- STARTTLS 有効/無効
- 送信元メールアドレス

### 実装
- `Setting` モデルに SMTP 関連フィールドを追加
- `SmtpSettingsForm` フォームオブジェクトを作成
- `ApplicationMailer` で動的に SMTP 設定を適用

## Test plan

- [x] コントローラテスト追加（5 テスト）
- [x] 全テスト通過（165 テスト）

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)