### PR TITLE
タグプッシュ時に Docker イメージを ghcr.io にプッシュするワークフローを追加

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,52 @@
+name: Docker Build and Push
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
- `v*` パターンのタグプッシュ時に Docker イメージを自動ビルド
- ghcr.io (GitHub Container Registry) にプッシュ
- セマンティックバージョンタグを自動生成 (例: `v1.0.0` → `1.0.0`, `1.0`, `1`)
- Docker Buildx によるビルドキャッシュ活用

## 使い方
```bash
git tag v1.0.0
git push origin v1.0.0
```

→ `ghcr.io/aiuemon/kulip:1.0.0` にイメージがプッシュされる

## Test plan
- [ ] タグをプッシュして GitHub Actions がトリガーされることを確認
- [ ] ghcr.io にイメージがプッシュされることを確認

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)