### PR TITLE
タイムゾーン設定機能を追加

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -8,6 +8,7 @@ module Admin
       @pdf_form = Forms::PdfSettingsForm.new
       @notification_form = Forms::NotificationSettingsForm.new
       @smtp_form = Forms::SmtpSettingsForm.new
+      @timezone_form = Forms::TimezoneSettingsForm.new
     end
 
     def update_auth
@@ -143,6 +144,25 @@ module Admin
       end
     end
 
+    def update_timezone
+      @timezone_form = Forms::TimezoneSettingsForm.new(timezone_settings_params)
+
+      if @timezone_form.save
+        respond_to do |format|
+          format.turbo_stream { render_turbo_flash(:timezone, "タイムゾーン設定を更新しました。", :success) }
+          format.html { redirect_to admin_settings_path(anchor: "collapseTimezone"), notice: "タイムゾーン設定を更新しました。" }
+        end
+      else
+        respond_to do |format|
+          format.turbo_stream { render_turbo_flash(:timezone, @timezone_form.errors.full_messages.join(", "), :error) }
+          format.html do
+            load_other_forms
+            render :show, status: :unprocessable_entity
+          end
+        end
+      end
+    end
+
     def send_test_email
       to_address = params[:to_address]
 
@@ -200,6 +220,7 @@ module Admin
       @pdf_form ||= Forms::PdfSettingsForm.new
       @notification_form ||= Forms::NotificationSettingsForm.new
       @smtp_form ||= Forms::SmtpSettingsForm.new
+      @timezone_form ||= Forms::TimezoneSettingsForm.new
     end
 
     def auth_settings_params
@@ -231,6 +252,10 @@ module Admin
         :enabled, :address, :port, :authentication,
         :user_name, :password, :enable_starttls, :from_address
       )
+    end
+
+    def timezone_settings_params
+      params.require(:timezone_settings).permit(:timezone)
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,10 +9,15 @@ class ApplicationController < ActionController::Base
 
   before_action :require_setup_completed
   before_action :authenticate_user!
+  around_action :set_time_zone
 
   private
 
   def require_setup_completed
     redirect_to new_setup_path unless User.exists?
+  end
+
+  def set_time_zone(&block)
+    Time.use_zone(Setting.effective_timezone, &block)
   end
 end

--- a/app/models/forms/timezone_settings_form.rb
+++ b/app/models/forms/timezone_settings_form.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module Forms
+  class TimezoneSettingsForm
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    attribute :timezone, :string
+
+    validates :timezone, inclusion: { in: :valid_timezones, message: "は有効なタイムゾーンを選択してください" }
+
+    # 主要なタイムゾーンのリスト（地名と UTC オフセット）
+    TIMEZONE_OPTIONS = [
+      [ "Asia/Tokyo (+09:00)", "Asia/Tokyo" ],
+      [ "Asia/Seoul (+09:00)", "Asia/Seoul" ],
+      [ "Asia/Shanghai (+08:00)", "Asia/Shanghai" ],
+      [ "Asia/Hong_Kong (+08:00)", "Asia/Hong_Kong" ],
+      [ "Asia/Singapore (+08:00)", "Asia/Singapore" ],
+      [ "Asia/Bangkok (+07:00)", "Asia/Bangkok" ],
+      [ "Asia/Jakarta (+07:00)", "Asia/Jakarta" ],
+      [ "Asia/Kolkata (+05:30)", "Asia/Kolkata" ],
+      [ "Asia/Dubai (+04:00)", "Asia/Dubai" ],
+      [ "Europe/Moscow (+03:00)", "Europe/Moscow" ],
+      [ "Europe/Istanbul (+03:00)", "Europe/Istanbul" ],
+      [ "Europe/Berlin (+01:00)", "Europe/Berlin" ],
+      [ "Europe/Paris (+01:00)", "Europe/Paris" ],
+      [ "Europe/London (+00:00)", "Europe/London" ],
+      [ "UTC (+00:00)", "UTC" ],
+      [ "America/Sao_Paulo (-03:00)", "America/Sao_Paulo" ],
+      [ "America/New_York (-05:00)", "America/New_York" ],
+      [ "America/Chicago (-06:00)", "America/Chicago" ],
+      [ "America/Denver (-07:00)", "America/Denver" ],
+      [ "America/Los_Angeles (-08:00)", "America/Los_Angeles" ],
+      [ "Pacific/Honolulu (-10:00)", "Pacific/Honolulu" ],
+      [ "Pacific/Auckland (+12:00)", "Pacific/Auckland" ],
+      [ "Australia/Sydney (+10:00)", "Australia/Sydney" ]
+    ].freeze
+
+    def initialize(attributes = {})
+      super
+      load_from_settings if attributes.empty?
+    end
+
+    def save
+      return false unless valid?
+
+      Setting.timezone = timezone.presence || Setting::DEFAULT_TIMEZONE
+      true
+    rescue => e
+      errors.add(:base, e.message)
+      false
+    end
+
+    def persisted?
+      true
+    end
+
+    def to_key
+      [ :timezone_settings ]
+    end
+
+    def model_name
+      ActiveModel::Name.new(self, nil, "TimezoneSettings")
+    end
+
+    def self.timezone_options
+      TIMEZONE_OPTIONS
+    end
+
+    private
+
+    def load_from_settings
+      self.timezone = Setting.timezone
+    end
+
+    def valid_timezones
+      TIMEZONE_OPTIONS.map(&:last)
+    end
+  end
+end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -18,6 +18,8 @@ class Setting < RailsSettings::Base
   DEFAULT_AUTO_PURGE_DAYS = 7
   DEFAULT_PDF_MAX_PAGES = 20
 
+  DEFAULT_TIMEZONE = "Asia/Tokyo".freeze
+
   DEFAULT_NOTIFICATION_SUBJECT = "[kulip] 文字起こしが完了しました".freeze
   DEFAULT_NOTIFICATION_BODY = <<~BODY.freeze
     {{user_name}} 様
@@ -71,6 +73,9 @@ class Setting < RailsSettings::Base
   field :smtp_password, type: :string, default: ""
   field :smtp_enable_starttls, type: :boolean, default: true
   field :smtp_from_address, type: :string, default: ""
+
+  # === タイムゾーン設定 ===
+  field :timezone, type: :string, default: "Asia/Tokyo"
 
   # === 互換性メソッド ===
   class << self
@@ -169,6 +174,12 @@ class Setting < RailsSettings::Base
       end
 
       settings
+    end
+
+    # タイムゾーン設定
+    def effective_timezone
+      tz = timezone
+      tz.present? ? tz : DEFAULT_TIMEZONE
     end
   end
 end

--- a/app/views/admin/settings/show.html.erb
+++ b/app/views/admin/settings/show.html.erb
@@ -406,4 +406,42 @@
       </div>
     </div>
   </div>
+
+  <%# タイムゾーン設定 %>
+  <div class="accordion-item">
+    <h2 class="accordion-header">
+      <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseTimezone" aria-expanded="false" aria-controls="collapseTimezone">
+        タイムゾーン設定
+      </button>
+    </h2>
+    <div id="collapseTimezone" class="accordion-collapse collapse" data-bs-parent="#settingsAccordion">
+      <div class="accordion-body">
+        <div id="flash_timezone"></div>
+        <%= form_with model: @timezone_form, url: update_timezone_admin_settings_path, method: :patch do |f| %>
+          <% if @timezone_form.errors.any? %>
+            <div class="alert alert-danger">
+              <ul class="mb-0">
+                <% @timezone_form.errors.full_messages.each do |message| %>
+                  <li><%= message %></li>
+                <% end %>
+              </ul>
+            </div>
+          <% end %>
+
+          <div class="mb-3">
+            <%= f.label :timezone, "タイムゾーン", class: "form-label" %>
+            <%= f.select :timezone, Forms::TimezoneSettingsForm.timezone_options, {}, class: "form-select", style: "max-width: 300px;" %>
+            <div class="form-text">
+              システム全体で使用するタイムゾーンを設定します。<br>
+              現在の設定: <strong><%= Setting.effective_timezone %></strong>
+            </div>
+          </div>
+
+          <div class="d-grid gap-2 d-md-flex justify-content-md-end">
+            <%= f.submit "保存", class: "btn btn-primary" %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,7 @@ Rails.application.routes.draw do
       patch :update_pdf, on: :member
       patch :update_notification, on: :member
       patch :update_smtp, on: :member
+      patch :update_timezone, on: :member
       post :send_test_email, on: :member
     end
     resources :users, only: %i[index] do

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -35,6 +35,7 @@ module Admin
       assert_select "#collapseSmtp"
       assert_select "#collapseUserFiles"
       assert_select "#collapseNotification"
+      assert_select "#collapseTimezone"
     end
 
     # Auth settings tests
@@ -350,6 +351,38 @@ module Admin
 
       patch update_pdf_admin_settings_path, params: {
         pdf_settings: { max_pages: 50 }
+      }
+
+      assert_redirected_to root_path
+    end
+
+    # Timezone settings tests
+    test "update_timezone changes timezone" do
+      sign_in @admin
+
+      patch update_timezone_admin_settings_path, params: {
+        timezone_settings: { timezone: "America/New_York" }
+      }
+
+      assert_redirected_to admin_settings_path(anchor: "collapseTimezone")
+      assert_equal "America/New_York", Setting.timezone
+    end
+
+    test "update_timezone validates timezone" do
+      sign_in @admin
+
+      patch update_timezone_admin_settings_path, params: {
+        timezone_settings: { timezone: "Invalid/Timezone" }
+      }
+
+      assert_response :unprocessable_entity
+    end
+
+    test "update_timezone requires admin" do
+      sign_in @user
+
+      patch update_timezone_admin_settings_path, params: {
+        timezone_settings: { timezone: "America/New_York" }
       }
 
       assert_redirected_to root_path


### PR DESCRIPTION
## Summary

- 管理者設定画面からタイムゾーンを変更できるようにする機能を追加
- プルダウンメニューで主要都市と UTC オフセットを表示
- デフォルトは Asia/Tokyo (+09:00)

## 変更内容

- Setting モデルに `timezone` フィールドを追加
- `Forms::TimezoneSettingsForm` を新規作成
- 管理者設定画面にタイムゾーン設定セクションを追加
- `ApplicationController` の `around_action` でリクエスト全体にタイムゾーンを適用

## Test plan

- [x] `bin/rails test` 全テスト通過
- [ ] 管理画面でタイムゾーンを変更し、ページ内の時刻表示が切り替わることを確認

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)