### PR TITLE
OCR 結果が空の completed 画像に警告と再試行ボタンを表示

### DIFF
--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -42,6 +42,16 @@ class Image < ApplicationRecord
     purged_at.present?
   end
 
+  # ステータスが completed だが OCR 結果が空（不整合状態）
+  def ocr_result_missing?
+    completed? && ocr_result.blank? && !purged?
+  end
+
+  # 再試行が可能かどうか
+  def retryable?
+    !purged? && (failed? || pending? || ocr_result_missing?)
+  end
+
   # ファイルを削除（論理削除）
   def purge_file!
     return if purged?
@@ -54,7 +64,7 @@ class Image < ApplicationRecord
 
   # OCR 処理を再実行
   def retry_ocr!
-    return unless failed? || pending?
+    return unless retryable?
 
     update!(status: "pending", ocr_result: nil)
     enqueue_ocr_processing

--- a/app/views/images/show.html.erb
+++ b/app/views/images/show.html.erb
@@ -51,10 +51,8 @@
         </dl>
       </div>
       <div class="card-footer">
-        <% unless @image.purged? %>
-          <% if @image.failed? || @image.pending? %>
-            <%= link_to "再試行", retry_image_path(@image), class: "btn btn-warning btn-sm", data: { turbo_method: :post } %>
-          <% end %>
+        <% if @image.retryable? %>
+          <%= link_to "再試行", retry_image_path(@image), class: "btn btn-warning btn-sm", data: { turbo_method: :post } %>
         <% end %>
         <%= link_to "削除", image_path(@image), class: "btn btn-danger btn-sm", data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } %>
       </div>
@@ -94,6 +92,14 @@
     </div>
     <div class="card-body">
       <pre class="mb-0" style="white-space: pre-wrap; word-wrap: break-word;"><%= @image.ocr_result %></pre>
+    </div>
+  </div>
+<% elsif @image.ocr_result_missing? %>
+  <div class="card mb-4 border-warning">
+    <div class="card-header bg-warning text-dark">OCR 結果</div>
+    <div class="card-body">
+      <p class="mb-2">OCR 処理が正常に完了しませんでした。「再試行」ボタンをクリックして再処理してください。</p>
+      <%= link_to "再試行", retry_image_path(@image), class: "btn btn-warning", data: { turbo_method: :post } %>
     </div>
   </div>
 <% elsif @image.purged? %>

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -135,4 +135,64 @@ class ImageTest < ActiveSupport::TestCase
 
     assert_equal original_purged_at, image.purged_at
   end
+
+  # ocr_result_missing? tests
+  test "ocr_result_missing? returns true when completed but ocr_result is blank" do
+    image = images(:completed_image)
+    image.ocr_result = nil
+    assert image.ocr_result_missing?
+
+    image.ocr_result = ""
+    assert image.ocr_result_missing?
+  end
+
+  test "ocr_result_missing? returns false when completed and ocr_result is present" do
+    image = images(:completed_image)
+    image.ocr_result = "Some OCR result"
+    assert_not image.ocr_result_missing?
+  end
+
+  test "ocr_result_missing? returns false when not completed" do
+    image = images(:pending_image)
+    image.ocr_result = nil
+    assert_not image.ocr_result_missing?
+  end
+
+  test "ocr_result_missing? returns false when purged" do
+    image = images(:purged_image)
+    assert_not image.ocr_result_missing?
+  end
+
+  # retryable? tests
+  test "retryable? returns true for failed images" do
+    image = images(:failed_image)
+    assert image.retryable?
+  end
+
+  test "retryable? returns true for pending images" do
+    image = images(:pending_image)
+    assert image.retryable?
+  end
+
+  test "retryable? returns true for completed images with missing ocr_result" do
+    image = images(:completed_image)
+    image.ocr_result = nil
+    assert image.retryable?
+  end
+
+  test "retryable? returns false for completed images with ocr_result" do
+    image = images(:completed_image)
+    image.ocr_result = "Some result"
+    assert_not image.retryable?
+  end
+
+  test "retryable? returns false for purged images" do
+    image = images(:purged_image)
+    assert_not image.retryable?
+  end
+
+  test "retryable? returns false for processing images" do
+    image = images(:processing_image)
+    assert_not image.retryable?
+  end
 end


### PR DESCRIPTION
## Summary

- ステータスが `completed` だが `ocr_result` が空の場合、警告メッセージと再試行ボタンを表示
- この不整合状態からユーザーが自己修復できるようにする

## 変更内容

- `Image#ocr_result_missing?`: ステータスが completed で ocr_result が空かどうかを判定
- `Image#retryable?`: 再試行可能かどうかを判定（failed, pending, ocr_result_missing?）
- `Image#retry_ocr!`: `retryable?` を使用するように変更
- ビュー: `ocr_result_missing?` の場合に警告カードと再試行ボタンを表示

## Test plan

- [x] `bin/rails test` 全テスト通過
- [ ] ステータス completed で ocr_result が空の画像で警告が表示されることを確認
- [ ] 再試行ボタンで OCR 処理が再実行されることを確認

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)