### PR TITLE
OCR ジョブで予期しない例外発生時もステータスを failed に更新

### DIFF
--- a/app/jobs/ocr_process_job.rb
+++ b/app/jobs/ocr_process_job.rb
@@ -68,6 +68,10 @@ class OcrProcessJob < ApplicationJob
     Rails.logger.error "OCR processing failed for image #{image.id}: #{e.message}"
     image.update!(status: "failed", ocr_result: "Error: #{e.message}")
     raise
+  rescue StandardError => e
+    Rails.logger.error "Unexpected error processing PDF image #{image.id}: #{e.class} - #{e.message}"
+    image.update!(status: "failed", ocr_result: "Error: #{e.message}")
+    raise
   end
 
   def format_page_result(page_number, filename, result)
@@ -106,6 +110,10 @@ class OcrProcessJob < ApplicationJob
     raise
   rescue OcrApiClient::Error => e
     Rails.logger.error "OCR processing failed for image #{image.id}: #{e.message}"
+    image.update!(status: "failed", ocr_result: "Error: #{e.message}")
+    raise
+  rescue StandardError => e
+    Rails.logger.error "Unexpected error processing image #{image.id}: #{e.class} - #{e.message}"
     image.update!(status: "failed", ocr_result: "Error: #{e.message}")
     raise
   end


### PR DESCRIPTION
## Summary

- OCR ジョブで予期しない例外が発生した場合もステータスを `failed` に更新
- これにより、ユーザーが「再試行」ボタンで処理を再実行できるようになる

## 変更内容

- `process_pdf` と `process_image` に `rescue StandardError` ブロックを追加
- 予期しない例外でもログ出力とステータス更新を行う

## Test plan

- [x] `bin/rails test test/jobs/ocr_process_job_test.rb` 通過

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)