### PR TITLE
ImageGroup モデルの N+1 クエリを解消

### DIFF
--- a/app/models/image_group.rb
+++ b/app/models/image_group.rb
@@ -18,19 +18,21 @@ class ImageGroup < ApplicationRecord
   end
 
   def all_completed?
-    images.any? && images.all?(&:completed?)
+    total = status_counts.values.sum
+    total > 0 && status_counts["completed"].to_i == total
   end
 
   def any_failed?
-    images.any?(&:failed?)
+    status_counts["failed"].to_i > 0
   end
 
   def all_failed?
-    images.any? && images.all?(&:failed?)
+    total = status_counts.values.sum
+    total > 0 && status_counts["failed"].to_i == total
   end
 
   def processing?
-    images.any?(&:processing?)
+    status_counts["processing"].to_i > 0
   end
 
   def status_summary
@@ -39,5 +41,21 @@ class ImageGroup < ApplicationRecord
     return "一部失敗" if any_failed?
     return "完了" if all_completed?
     "待機中"
+  end
+
+  private
+
+  # ステータスごとのカウントをメモ化
+  # images がロード済みの場合は Ruby で集計、未ロードの場合は DB クエリを使用
+  def status_counts
+    @status_counts ||= build_status_counts
+  end
+
+  def build_status_counts
+    if images.loaded?
+      images.group_by(&:status).transform_values(&:size)
+    else
+      images.group(:status).count
+    end
   end
 end


### PR DESCRIPTION
## Summary

- ImageGroup の `all_completed?`, `any_failed?`, `all_failed?`, `processing?`, `status_summary` メソッドで発生していた N+1 クエリを解消
- `status_counts` メソッドを追加し、ステータスごとのカウントをメモ化
- images がロード済みの場合は Ruby で集計、未ロードの場合は DB の `GROUP BY` クエリを使用

## 変更内容

### Before

```ruby
def all_completed?
  images.any? && images.all?(&:completed?)  # N+1
end

def status_summary
  return "処理中" if processing?    # クエリ発行
  return "失敗" if all_failed?      # クエリ発行
  return "一部失敗" if any_failed?  # クエリ発行
  return "完了" if all_completed?   # クエリ発行
  "待機中"
end
```

### After

```ruby
def all_completed?
  total = status_counts.values.sum
  total > 0 && status_counts["completed"].to_i == total
end

def status_counts
  @status_counts ||= build_status_counts
end

def build_status_counts
  if images.loaded?
    images.group_by(&:status).transform_values(&:size)
  else
    images.group(:status).count  # 1回の GROUP BY クエリ
  end
end
```

## Test plan

- [x] `bin/rails test test/models/image_group_test.rb` - 12 tests, 0 failures
- [x] `bin/rubocop app/models/image_group.rb` - no offenses

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)