### PR TITLE
OcrProcessJob の責務分割リファクタリング

### DIFF
--- a/app/jobs/ocr_process_job.rb
+++ b/app/jobs/ocr_process_job.rb
@@ -8,135 +8,27 @@ class OcrProcessJob < ApplicationJob
 
   def perform(image_id)
     image = Image.find_by(id: image_id)
-    return unless image
-    return unless image.pending?
-    return unless image.file.attached?
+    return unless processable?(image)
 
-    if pdf_file?(image)
-      process_pdf(image)
-    else
-      process_image(image)
-    end
+    strategy = select_strategy(image)
+    strategy.process
   end
 
   private
 
+  def processable?(image)
+    image && image.pending? && image.file.attached?
+  end
+
+  def select_strategy(image)
+    if pdf_file?(image)
+      OcrProcessing::PdfStrategy.new(image)
+    else
+      OcrProcessing::ImageStrategy.new(image)
+    end
+  end
+
   def pdf_file?(image)
     image.file.content_type == "application/pdf"
-  end
-
-  def process_pdf(image)
-    image.update!(status: "processing")
-
-    start_time = Time.current
-
-    pdf_service = PdfProcessingService.new(
-      image.file.download,
-      image.file.filename.to_s
-    )
-
-    page_images = pdf_service.convert_to_images
-    client = OcrApiClient.new
-    results = []
-
-    page_images.each do |page|
-      page_result = client.transcribe(
-        image_data: page[:image_data],
-        filename: page[:filename],
-        content_type: "image/jpeg"
-      )
-      results << format_page_result(page[:page_number], page[:filename], page_result)
-    end
-
-    duration = (Time.current - start_time).to_i
-    combined_result = results.join("\n\n---\n\n")
-
-    image.update!(
-      status: "completed",
-      ocr_result: combined_result,
-      ocr_duration: duration,
-      ocr_completed_at: Time.current
-    )
-
-    send_completion_notification(image)
-
-  rescue PdfProcessingService::Error => e
-    Rails.logger.error "PDF processing failed for image #{image.id}: #{e.message}"
-    image.update!(status: "failed", ocr_result: "Error: #{e.message}")
-    raise
-  rescue OcrApiClient::Error => e
-    Rails.logger.error "OCR processing failed for image #{image.id}: #{e.message}"
-    image.update!(status: "failed", ocr_result: "Error: #{e.message}")
-    raise
-  rescue StandardError => e
-    Rails.logger.error "Unexpected error processing PDF image #{image.id}: #{e.class} - #{e.message}"
-    image.update!(status: "failed", ocr_result: "Error: #{e.message}")
-    raise
-  end
-
-  def format_page_result(page_number, filename, result)
-    "## ページ #{page_number} (#{filename})\n\n#{result}"
-  end
-
-  def process_image(image)
-    image.update!(status: "processing")
-
-    start_time = Time.current
-
-    # HEIC/HEIF の場合は PNG に変換
-    image_data, filename, content_type = prepare_image_data(image)
-
-    client = OcrApiClient.new
-    result = client.transcribe(
-      image_data: image_data,
-      filename: filename,
-      content_type: content_type
-    )
-
-    duration = (Time.current - start_time).to_i
-
-    image.update!(
-      status: "completed",
-      ocr_result: result,
-      ocr_duration: duration,
-      ocr_completed_at: Time.current
-    )
-
-    send_completion_notification(image)
-
-  rescue HeicProcessingService::Error => e
-    Rails.logger.error "HEIC processing failed for image #{image.id}: #{e.message}"
-    image.update!(status: "failed", ocr_result: "Error: #{e.message}")
-    raise
-  rescue OcrApiClient::Error => e
-    Rails.logger.error "OCR processing failed for image #{image.id}: #{e.message}"
-    image.update!(status: "failed", ocr_result: "Error: #{e.message}")
-    raise
-  rescue StandardError => e
-    Rails.logger.error "Unexpected error processing image #{image.id}: #{e.class} - #{e.message}"
-    image.update!(status: "failed", ocr_result: "Error: #{e.message}")
-    raise
-  end
-
-  def prepare_image_data(image)
-    original_data = image.file.download
-    original_filename = image.file.filename.to_s
-    original_content_type = image.file.content_type
-
-    if HeicProcessingService.heic?(original_content_type)
-      service = HeicProcessingService.new(original_data, original_filename)
-      converted = service.convert_to_png
-      [ converted[:image_data], converted[:filename], converted[:content_type] ]
-    else
-      [ original_data, original_filename, original_content_type ]
-    end
-  end
-
-  def send_completion_notification(image)
-    return unless Setting.notification_email_enabled?
-
-    OcrCompletionMailer.completion_notification(image).deliver_later
-  rescue StandardError => e
-    Rails.logger.error "Failed to send completion notification for image #{image.id}: #{e.message}"
   end
 end

--- a/app/services/ocr_processing/base_strategy.rb
+++ b/app/services/ocr_processing/base_strategy.rb
@@ -1,0 +1,59 @@
+module OcrProcessing
+  # OCR 処理の基底クラス
+  # Template Method パターンで共通処理を提供し、サブクラスで具体的な処理を実装
+  class BaseStrategy
+    attr_reader :image, :client
+
+    def initialize(image, client = nil)
+      @image = image
+      @client = client || OcrApiClient.new
+    end
+
+    # メインの処理メソッド
+    # サブクラスは execute_ocr を実装する
+    def process
+      image.update!(status: "processing")
+      start_time = Time.current
+
+      result = execute_ocr
+
+      duration = (Time.current - start_time).to_i
+      complete_processing(result, duration)
+      send_completion_notification
+    rescue StandardError => e
+      handle_error(e)
+      raise
+    end
+
+    private
+
+    # サブクラスで実装する OCR 処理
+    # @return [String] OCR 結果
+    def execute_ocr
+      raise NotImplementedError, "#{self.class} must implement #execute_ocr"
+    end
+
+    def complete_processing(result, duration)
+      image.update!(
+        status: "completed",
+        ocr_result: result,
+        ocr_duration: duration,
+        ocr_completed_at: Time.current
+      )
+    end
+
+    def handle_error(error)
+      error_type = error.class.name.split("::").last
+      Rails.logger.error "#{error_type} for image #{image.id}: #{error.message}"
+      image.update!(status: "failed", ocr_result: "Error: #{error.message}")
+    end
+
+    def send_completion_notification
+      return unless Setting.notification_email_enabled?
+
+      OcrCompletionMailer.completion_notification(image).deliver_later
+    rescue StandardError => e
+      Rails.logger.error "Failed to send completion notification for image #{image.id}: #{e.message}"
+    end
+  end
+end

--- a/app/services/ocr_processing/image_strategy.rb
+++ b/app/services/ocr_processing/image_strategy.rb
@@ -1,0 +1,33 @@
+module OcrProcessing
+  # 通常画像（JPEG, PNG, HEIC 等）の OCR 処理
+  class ImageStrategy < BaseStrategy
+    private
+
+    def execute_ocr
+      image_data, filename, content_type = prepare_image_data
+      client.transcribe(
+        image_data: image_data,
+        filename: filename,
+        content_type: content_type
+      )
+    end
+
+    def prepare_image_data
+      original_data = image.file.download
+      original_filename = image.file.filename.to_s
+      original_content_type = image.file.content_type
+
+      if HeicProcessingService.heic?(original_content_type)
+        convert_heic(original_data, original_filename)
+      else
+        [ original_data, original_filename, original_content_type ]
+      end
+    end
+
+    def convert_heic(data, filename)
+      service = HeicProcessingService.new(data, filename)
+      converted = service.convert_to_png
+      [ converted[:image_data], converted[:filename], converted[:content_type] ]
+    end
+  end
+end

--- a/app/services/ocr_processing/pdf_strategy.rb
+++ b/app/services/ocr_processing/pdf_strategy.rb
@@ -1,0 +1,40 @@
+module OcrProcessing
+  # PDF ファイルの OCR 処理
+  # PDF を画像に変換し、各ページを OCR 処理して結果を結合
+  class PdfStrategy < BaseStrategy
+    private
+
+    def execute_ocr
+      page_images = convert_pdf_to_images
+      results = process_pages(page_images)
+      combine_results(results)
+    end
+
+    def convert_pdf_to_images
+      pdf_service = PdfProcessingService.new(
+        image.file.download,
+        image.file.filename.to_s
+      )
+      pdf_service.convert_to_images
+    end
+
+    def process_pages(page_images)
+      page_images.map do |page|
+        page_result = client.transcribe(
+          image_data: page[:image_data],
+          filename: page[:filename],
+          content_type: "image/jpeg"
+        )
+        format_page_result(page[:page_number], page[:filename], page_result)
+      end
+    end
+
+    def format_page_result(page_number, filename, result)
+      "## ページ #{page_number} (#{filename})\n\n#{result}"
+    end
+
+    def combine_results(results)
+      results.join("\n\n---\n\n")
+    end
+  end
+end

--- a/test/services/ocr_processing/base_strategy_test.rb
+++ b/test/services/ocr_processing/base_strategy_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+module OcrProcessing
+  class BaseStrategyTest < ActiveSupport::TestCase
+    setup do
+      # OCR API 設定をセットアップ
+      Setting.ocr_endpoint = "http://localhost:11434/api/generate"
+    end
+
+    test "raises NotImplementedError when execute_ocr is not implemented" do
+      image = images(:pending_image)
+      strategy = BaseStrategy.new(image)
+
+      assert_raises(NotImplementedError) do
+        strategy.send(:execute_ocr)
+      end
+    end
+
+    test "accepts custom client" do
+      image = images(:pending_image)
+      custom_client = OcrApiClient.new
+      strategy = BaseStrategy.new(image, custom_client)
+
+      assert_equal custom_client, strategy.client
+    end
+
+    test "initializes with default client when not provided" do
+      image = images(:pending_image)
+      strategy = BaseStrategy.new(image)
+
+      assert_instance_of OcrApiClient, strategy.client
+    end
+  end
+end

--- a/test/services/ocr_processing/image_strategy_test.rb
+++ b/test/services/ocr_processing/image_strategy_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+module OcrProcessing
+  class ImageStrategyTest < ActiveSupport::TestCase
+    setup do
+      Setting.ocr_endpoint = "http://localhost:11434/api/generate"
+    end
+
+    test "inherits from BaseStrategy" do
+      assert ImageStrategy < BaseStrategy
+    end
+
+    test "initializes with image" do
+      image = images(:pending_image)
+      strategy = ImageStrategy.new(image)
+
+      assert_equal image, strategy.image
+      assert_instance_of OcrApiClient, strategy.client
+    end
+  end
+end

--- a/test/services/ocr_processing/pdf_strategy_test.rb
+++ b/test/services/ocr_processing/pdf_strategy_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+module OcrProcessing
+  class PdfStrategyTest < ActiveSupport::TestCase
+    setup do
+      Setting.ocr_endpoint = "http://localhost:11434/api/generate"
+    end
+
+    test "inherits from BaseStrategy" do
+      assert PdfStrategy < BaseStrategy
+    end
+
+    test "initializes with image" do
+      image = images(:pending_image)
+      strategy = PdfStrategy.new(image)
+
+      assert_equal image, strategy.image
+      assert_instance_of OcrApiClient, strategy.client
+    end
+
+    test "format_page_result formats correctly" do
+      image = images(:pending_image)
+      strategy = PdfStrategy.new(image)
+
+      result = strategy.send(:format_page_result, 1, "page_1.jpg", "OCR text")
+
+      assert_equal "## ページ 1 (page_1.jpg)\n\nOCR text", result
+    end
+
+    test "combine_results joins with separator" do
+      image = images(:pending_image)
+      strategy = PdfStrategy.new(image)
+
+      results = [ "Page 1 content", "Page 2 content" ]
+      combined = strategy.send(:combine_results, results)
+
+      assert_equal "Page 1 content\n\n---\n\nPage 2 content", combined
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Strategy パターンを導入し、OcrProcessJob から PDF/画像処理の責務を分離
- OcrProcessJob を 142行 → 34行（**108行削減**）に簡素化
- 単一責務原則（SRP）を遵守し、テストしやすい構造に

## 新規ファイル

| ファイル | 説明 |
|----------|------|
| `app/services/ocr_processing/base_strategy.rb` | 基底クラス。Template Method パターンで共通処理を提供 |
| `app/services/ocr_processing/image_strategy.rb` | 通常画像（JPEG, PNG, HEIC）の OCR 処理 |
| `app/services/ocr_processing/pdf_strategy.rb` | PDF の OCR 処理（ページごとに処理して結合）|

## アーキテクチャ

### Before

```ruby
class OcrProcessJob < ApplicationJob
  def perform(image_id)
    if pdf_file?(image)
      process_pdf(image)    # 50行
    else
      process_image(image)  # 40行
    end
  end
  # + エラーハンドリング重複、通知ロジック混在...
end
```

### After

```ruby
class OcrProcessJob < ApplicationJob
  def perform(image_id)
    return unless processable?(image)
    strategy = select_strategy(image)
    strategy.process
  end
end

# 各 Strategy が独立して責務を持つ
module OcrProcessing
  class BaseStrategy      # 共通処理: エラーハンドリング、通知、時間計測
  class ImageStrategy     # 画像固有の OCR 処理
  class PdfStrategy       # PDF 固有の OCR 処理
end
```

## 改善点

| 観点 | Before | After |
|------|--------|-------|
| OcrProcessJob の行数 | 142行 | 34行 |
| エラーハンドリング | 4箇所で重複 | BaseStrategy に集約 |
| 通知送信 | 2箇所で重複 | BaseStrategy に集約 |
| 新形式への対応 | Job を大幅修正 | 新 Strategy を追加するだけ |

## Test plan

- [x] `bin/rails test test/jobs/ocr_process_job_test.rb` - 5 tests, 0 failures
- [x] `bin/rails test test/services/ocr_processing/` - 9 tests, 0 failures
- [x] `bin/rubocop` - no offenses

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)