### PR TITLE
identity_provider_params の to_unsafe_h 使用を修正

### DIFF
--- a/app/controllers/admin/identity_providers_controller.rb
+++ b/app/controllers/admin/identity_providers_controller.rb
@@ -1,5 +1,9 @@
 module Admin
   class IdentityProvidersController < BaseController
+    # プロバイダータイプごとの許可される settings キー
+    SAML_SETTINGS_KEYS = %w[idp_sso_url idp_slo_url idp_cert sp_entity_id].freeze
+    OIDC_SETTINGS_KEYS = %w[issuer client_id client_secret redirect_uri].freeze
+
     before_action :set_identity_provider, only: %i[show edit update destroy]
 
     def index
@@ -89,12 +93,30 @@ module Admin
         :provider_type, :name, :slug, :enabled, :show_on_login
       )
 
-      # settings をネストしたパラメータから取得
+      # settings をホワイトリスト形式でフィルタリング
       if params[:identity_provider][:settings].present?
-        permitted[:settings] = params[:identity_provider][:settings].to_unsafe_h
+        permitted[:settings] = filter_settings_params
       end
 
       permitted
+    end
+
+    def filter_settings_params
+      provider_type = params[:identity_provider][:provider_type]
+      whitelist = settings_whitelist_for(provider_type)
+
+      params[:identity_provider][:settings]
+        .to_unsafe_h
+        .slice(*whitelist)
+        .transform_values { |v| v.is_a?(String) ? v.strip : v }
+    end
+
+    def settings_whitelist_for(provider_type)
+      case provider_type
+      when "saml" then SAML_SETTINGS_KEYS
+      when "oidc" then OIDC_SETTINGS_KEYS
+      else []
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

- `to_unsafe_h` の使用をホワイトリスト形式でフィルタリングし、セキュリティリスクを軽減
- プロバイダータイプ（SAML/OIDC）に応じた許可キーのみを抽出

## 変更内容

### Before

```ruby
def identity_provider_params
  permitted = params.require(:identity_provider).permit(...)

  if params[:identity_provider][:settings].present?
    permitted[:settings] = params[:identity_provider][:settings].to_unsafe_h  # 危険
  end

  permitted
end
```

### After

```ruby
SAML_SETTINGS_KEYS = %w[idp_sso_url idp_slo_url idp_cert sp_entity_id].freeze
OIDC_SETTINGS_KEYS = %w[issuer client_id client_secret redirect_uri].freeze

def identity_provider_params
  # ...
  if params[:identity_provider][:settings].present?
    permitted[:settings] = filter_settings_params  # ホワイトリストでフィルタリング
  end
  permitted
end

def filter_settings_params
  provider_type = params[:identity_provider][:provider_type]
  whitelist = settings_whitelist_for(provider_type)

  params[:identity_provider][:settings]
    .to_unsafe_h
    .slice(*whitelist)
    .transform_values { |v| v.is_a?(String) ? v.strip : v }
end
```

## Test plan

- [x] `bin/rails test test/controllers/admin/identity_providers_controller_test.rb` - 6 tests, 0 failures
- [x] `bin/rubocop` - no offenses

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)