### PR TITLE
generate_download_content メソッドの重複を解消

### DIFF
--- a/app/controllers/image_groups_controller.rb
+++ b/app/controllers/image_groups_controller.rb
@@ -112,26 +112,12 @@ class ImageGroupsController < ApplicationController
     nil
   end
 
-  def generate_download_content(image, format)
-    base_name = File.basename(image.name, ".*")
-
-    case format
-    when "md", "markdown"
-      content = "# #{image.name}\n\n#{image.ocr_result}"
-      [ content, "#{base_name}.md", "text/markdown" ]
-    when "txt", "text"
-      [ image.ocr_result, "#{base_name}.txt", "text/plain" ]
-    else
-      [ image.ocr_result, "#{base_name}.txt", "text/plain" ]
-    end
-  end
-
   def generate_zip(images, format)
     require "zip"
 
     stringio = Zip::OutputStream.write_buffer do |zio|
       images.each do |image|
-        content, filename, = generate_download_content(image, format)
+        content, filename, = DownloadContentFormatter.new(image, format).generate
         zio.put_next_entry(filename)
         zio.write(content)
       end

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -31,7 +31,7 @@ class ImagesController < ApplicationController
     end
 
     format = params[:format] || "txt"
-    content, filename, content_type = generate_download_content(@image, format)
+    content, filename, content_type = DownloadContentFormatter.new(@image, format).generate
 
     send_data content, filename: filename, type: content_type, disposition: "attachment"
   end
@@ -40,19 +40,5 @@ class ImagesController < ApplicationController
 
   def set_image
     @image = current_user.images.find(params[:id])
-  end
-
-  def generate_download_content(image, format)
-    base_name = File.basename(image.name, ".*")
-
-    case format
-    when "md", "markdown"
-      content = "# #{image.name}\n\n#{image.ocr_result}"
-      [ content, "#{base_name}.md", "text/markdown" ]
-    when "txt", "text"
-      [ image.ocr_result, "#{base_name}.txt", "text/plain" ]
-    else
-      [ image.ocr_result, "#{base_name}.txt", "text/plain" ]
-    end
   end
 end

--- a/app/services/download_content_formatter.rb
+++ b/app/services/download_content_formatter.rb
@@ -1,0 +1,45 @@
+# OCR 結果のダウンロードコンテンツを生成するサービス
+class DownloadContentFormatter
+  FORMATS = {
+    "md" => :markdown,
+    "markdown" => :markdown,
+    "txt" => :text,
+    "text" => :text
+  }.freeze
+
+  attr_reader :image, :format
+
+  def initialize(image, format = "txt")
+    @image = image
+    @format = format
+  end
+
+  # @return [Array<String, String, String>] [content, filename, content_type]
+  def generate
+    case format_type
+    when :markdown
+      markdown_content
+    else
+      text_content
+    end
+  end
+
+  private
+
+  def format_type
+    FORMATS[format] || :text
+  end
+
+  def base_name
+    File.basename(image.name, ".*")
+  end
+
+  def markdown_content
+    content = "# #{image.name}\n\n#{image.ocr_result}"
+    [ content, "#{base_name}.md", "text/markdown" ]
+  end
+
+  def text_content
+    [ image.ocr_result, "#{base_name}.txt", "text/plain" ]
+  end
+end

--- a/test/services/download_content_formatter_test.rb
+++ b/test/services/download_content_formatter_test.rb
@@ -1,0 +1,72 @@
+require "test_helper"
+
+class DownloadContentFormatterTest < ActiveSupport::TestCase
+  setup do
+    @image = images(:completed_image)
+    @image.update_column(:ocr_result, "This is OCR result text")
+  end
+
+  test "generates text content by default" do
+    formatter = DownloadContentFormatter.new(@image)
+    content, filename, content_type = formatter.generate
+
+    assert_equal @image.ocr_result, content
+    assert_match(/\.txt$/, filename)
+    assert_equal "text/plain", content_type
+  end
+
+  test "generates text content for txt format" do
+    formatter = DownloadContentFormatter.new(@image, "txt")
+    content, filename, content_type = formatter.generate
+
+    assert_equal @image.ocr_result, content
+    assert_match(/\.txt$/, filename)
+    assert_equal "text/plain", content_type
+  end
+
+  test "generates text content for text format" do
+    formatter = DownloadContentFormatter.new(@image, "text")
+    content, filename, content_type = formatter.generate
+
+    assert_equal @image.ocr_result, content
+    assert_match(/\.txt$/, filename)
+    assert_equal "text/plain", content_type
+  end
+
+  test "generates markdown content for md format" do
+    formatter = DownloadContentFormatter.new(@image, "md")
+    content, filename, content_type = formatter.generate
+
+    assert_includes content, "# #{@image.name}"
+    assert_includes content, @image.ocr_result
+    assert_match(/\.md$/, filename)
+    assert_equal "text/markdown", content_type
+  end
+
+  test "generates markdown content for markdown format" do
+    formatter = DownloadContentFormatter.new(@image, "markdown")
+    content, filename, content_type = formatter.generate
+
+    assert_includes content, "# #{@image.name}"
+    assert_includes content, @image.ocr_result
+    assert_match(/\.md$/, filename)
+    assert_equal "text/markdown", content_type
+  end
+
+  test "falls back to text for unknown format" do
+    formatter = DownloadContentFormatter.new(@image, "unknown")
+    content, filename, content_type = formatter.generate
+
+    assert_equal @image.ocr_result, content
+    assert_match(/\.txt$/, filename)
+    assert_equal "text/plain", content_type
+  end
+
+  test "uses base name without extension for filename" do
+    @image.update_column(:name, "document.png")
+    formatter = DownloadContentFormatter.new(@image, "txt")
+    _, filename, _ = formatter.generate
+
+    assert_equal "document.txt", filename
+  end
+end


### PR DESCRIPTION
## Summary

- `DownloadContentFormatter` サービスクラスを作成し、重複コードを統合
- `ImagesController` と `ImageGroupsController` から重複メソッドを削除

## 変更内容

### Before

```ruby
# ImagesController と ImageGroupsController の両方に同じ実装が存在
def generate_download_content(image, format)
  base_name = File.basename(image.name, ".*")
  case format
  when "md", "markdown"
    content = "# #{image.name}\n\n#{image.ocr_result}"
    [ content, "#{base_name}.md", "text/markdown" ]
  when "txt", "text"
    [ image.ocr_result, "#{base_name}.txt", "text/plain" ]
  else
    [ image.ocr_result, "#{base_name}.txt", "text/plain" ]
  end
end
```

### After

```ruby
# app/services/download_content_formatter.rb
class DownloadContentFormatter
  def initialize(image, format = "txt")
    @image = image
    @format = format
  end

  def generate
    case format_type
    when :markdown then markdown_content
    else text_content
    end
  end
  # ...
end

# コントローラでの使用
content, filename, content_type = DownloadContentFormatter.new(@image, format).generate
```

## 新規ファイル

- `app/services/download_content_formatter.rb`
- `test/services/download_content_formatter_test.rb`

## Test plan

- [x] `bin/rails test test/services/download_content_formatter_test.rb` - 7 tests, 0 failures
- [x] `bin/rails test test/controllers/images_controller_test.rb` - 5 tests, 0 failures
- [x] `bin/rails test test/controllers/image_groups_controller_test.rb` - 15 tests, 0 failures
- [x] `bin/rubocop` - no offenses

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)