### PR TITLE
SAML SP メタデータの URL 確認とダウンロード機能を追加

### DIFF
--- a/app/controllers/saml_metadata_controller.rb
+++ b/app/controllers/saml_metadata_controller.rb
@@ -1,0 +1,45 @@
+class SamlMetadataController < ApplicationController
+  skip_before_action :authenticate_user!
+
+  def show
+    settings = saml_settings
+    meta = OneLogin::RubySaml::Metadata.new
+    xml = meta.generate(settings, true)
+
+    if params[:download].present?
+      send_data xml, filename: "saml_sp_metadata.xml", type: "application/xml", disposition: "attachment"
+    else
+      render xml: xml
+    end
+  end
+
+  private
+
+  def saml_settings
+    settings = OneLogin::RubySaml::Settings.new
+
+    # SP 設定
+    settings.sp_entity_id = sp_entity_id
+    settings.assertion_consumer_service_url = assertion_consumer_service_url
+    settings.name_identifier_format = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
+
+    settings
+  end
+
+  def sp_entity_id
+    # 登録済み SAML IdP の sp_entity_id を取得、なければデフォルト
+    saml_idp = IdentityProvider.where(provider_type: "saml").first
+    saml_idp&.settings&.dig("sp_entity_id").presence || request.base_url
+  end
+
+  def assertion_consumer_service_url
+    # OmniAuth SAML の ACS URL パターン
+    # 複数の IdP がある場合は汎用的なパターンを表示
+    saml_idp = IdentityProvider.where(provider_type: "saml").first
+    if saml_idp
+      "#{request.base_url}/users/auth/saml_#{saml_idp.slug}/callback"
+    else
+      "#{request.base_url}/users/auth/saml_{slug}/callback"
+    end
+  end
+end

--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -1,0 +1,24 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = { target: String }
+
+  copy() {
+    const targetElement = document.querySelector(this.targetValue)
+    if (!targetElement) return
+
+    const text = targetElement.value || targetElement.textContent
+
+    navigator.clipboard.writeText(text).then(() => {
+      const originalText = this.element.textContent
+      this.element.textContent = "コピーしました"
+      setTimeout(() => {
+        this.element.textContent = originalText
+      }, 2000)
+    }).catch(() => {
+      // フォールバック: 古いブラウザ向け
+      targetElement.select()
+      document.execCommand("copy")
+    })
+  }
+}

--- a/app/views/admin/identity_providers/index.html.erb
+++ b/app/views/admin/identity_providers/index.html.erb
@@ -6,6 +6,29 @@
   </div>
 </div>
 
+<%# SAML SP メタデータ %>
+<div class="card mb-4">
+  <div class="card-header">
+    SAML SP メタデータ
+  </div>
+  <div class="card-body">
+    <p class="card-text text-muted">IdP に本システムを SP として登録する際に、このメタデータ URL または XML ファイルを使用してください。</p>
+    <div class="mb-3">
+      <label class="form-label">メタデータ URL</label>
+      <div class="input-group">
+        <input type="text" class="form-control" value="<%= saml_metadata_url %>" readonly id="saml-metadata-url">
+        <button class="btn btn-outline-secondary" type="button" data-controller="clipboard" data-action="click->clipboard#copy" data-clipboard-target-value="#saml-metadata-url">
+          コピー
+        </button>
+      </div>
+    </div>
+    <div>
+      <%= link_to "XML ファイルをダウンロード", saml_metadata_path(download: true), class: "btn btn-outline-primary" %>
+      <%= link_to "メタデータを表示", saml_metadata_path, class: "btn btn-outline-secondary", target: "_blank" %>
+    </div>
+  </div>
+</div>
+
 <% if @identity_providers.any? %>
   <div class="table-responsive">
     <table class="table table-striped table-hover">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,6 +53,9 @@ Rails.application.routes.draw do
     resources :images, only: %i[index destroy]
   end
 
+  # SAML SP メタデータ
+  get "saml/metadata" => "saml_metadata#show", as: :saml_metadata
+
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check

--- a/test/controllers/saml_metadata_controller_test.rb
+++ b/test/controllers/saml_metadata_controller_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+class SamlMetadataControllerTest < ActionDispatch::IntegrationTest
+  test "show returns XML metadata" do
+    get saml_metadata_path
+    assert_response :success
+    assert_equal "application/xml; charset=utf-8", response.content_type
+    assert_includes response.body, "EntityDescriptor"
+  end
+
+  test "show with download param returns attachment" do
+    get saml_metadata_path(download: true)
+    assert_response :success
+    assert_match(/attachment/, response.headers["Content-Disposition"])
+    assert_match(/saml_sp_metadata\.xml/, response.headers["Content-Disposition"])
+  end
+
+  test "metadata includes sp entity id" do
+    get saml_metadata_path
+    assert_response :success
+    assert_includes response.body, "entityID="
+  end
+
+  test "metadata includes assertion consumer service" do
+    get saml_metadata_path
+    assert_response :success
+    assert_includes response.body, "AssertionConsumerService"
+  end
+end


### PR DESCRIPTION
## Summary
- /saml/metadata エンドポイントを追加し、SP メタデータを XML で提供
- IdP 設定ページにメタデータ URL 表示とダウンロードボタンを追加
- クリップボードコピー用の Stimulus コントローラーを追加

## Test plan
- [ ] IdP 設定ページで SAML SP メタデータセクションが表示されることを確認
- [ ] メタデータ URL をコピーできることを確認
- [ ] 「XML ファイルをダウンロード」ボタンで XML ファイルがダウンロードされることを確認
- [ ] 「メタデータを表示」リンクで XML が新しいタブで表示されることを確認

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)