### PR TITLE
Passkey (WebAuthn) 認証機能を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem "omniauth"
 gem "omniauth-rails_csrf_protection"
 gem "omniauth-saml"
 gem "omniauth_openid_connect"
+gem "webauthn"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
     addressable (2.8.9)
       public_suffix (>= 2.0.2, < 8.0)
     aes_key_wrap (1.1.0)
+    android_key_attestation (0.3.0)
     ast (2.4.3)
     attr_required (1.0.2)
     base64 (0.3.0)
@@ -103,8 +104,12 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    cbor (0.5.10.2)
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
+    cose (1.3.1)
+      cbor (~> 0.5.9)
+      openssl-signature_algorithm (~> 1.0)
     crass (1.0.6)
     date (3.5.1)
     debug (1.11.1)
@@ -177,6 +182,8 @@ GEM
     json-schema (6.2.0)
       addressable (~> 2.8)
       bigdecimal (>= 3.1, < 5)
+    jwt (3.1.2)
+      base64
     kamal (2.11.0)
       activesupport (>= 7.0)
       base64 (~> 0.2)
@@ -271,6 +278,9 @@ GEM
       tzinfo
       validate_url
       webfinger (~> 2.0)
+    openssl (4.0.1)
+    openssl-signature_algorithm (1.3.0)
+      openssl (> 2.0)
     orm_adapter (0.5.0)
     ostruct (0.6.3)
     pagy (43.4.4)
@@ -406,6 +416,8 @@ GEM
       ffi (~> 1.12)
       logger
     rubyzip (3.2.2)
+    safety_net_attestation (0.5.0)
+      jwt (>= 2.0, < 4.0)
     securerandom (0.4.1)
     selenium-webdriver (4.41.0)
       base64 (~> 0.2)
@@ -459,6 +471,10 @@ GEM
     thruster (0.1.19-x86_64-darwin)
     thruster (0.1.19-x86_64-linux)
     timeout (0.6.1)
+    tpm-key_attestation (0.14.1)
+      bindata (~> 2.4)
+      openssl (> 2.0)
+      openssl-signature_algorithm (~> 1.0)
     tsort (0.2.0)
     turbo-rails (2.0.23)
       actionpack (>= 7.1.0)
@@ -479,6 +495,14 @@ GEM
       actionview (>= 8.0.0)
       bindex (>= 0.4.0)
       railties (>= 8.0.0)
+    webauthn (3.4.3)
+      android_key_attestation (~> 0.3.0)
+      bindata (~> 2.4)
+      cbor (~> 0.5.9)
+      cose (~> 1.1)
+      openssl (>= 2.2)
+      safety_net_attestation (~> 0.5.0)
+      tpm-key_attestation (~> 0.14.0)
     webfinger (2.1.3)
       activesupport
       faraday (~> 2.0)
@@ -539,6 +563,7 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
+  webauthn
 
 BUNDLED WITH
    2.6.9

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -14,6 +14,13 @@ module Admin
         param_key: :auth_settings,
         permitted: %i[local_auth_enabled local_auth_show_on_login self_signup_enabled]
       },
+      passkey: {
+        form_class: Forms::PasskeySettingsForm,
+        message: "パスキー設定を更新しました。",
+        anchor: "collapseAuth",
+        param_key: :passkey_settings,
+        permitted: %i[enabled]
+      },
       ocr: {
         form_class: Forms::OcrSettingsForm,
         message: "OCR設定を更新しました。",

--- a/app/controllers/passkeys/credentials_controller.rb
+++ b/app/controllers/passkeys/credentials_controller.rb
@@ -1,0 +1,77 @@
+module Passkeys
+  class CredentialsController < ApplicationController
+    include ActionView::RecordIdentifier
+
+    before_action :ensure_passkey_enabled
+    before_action :set_credential, only: %i[update destroy]
+
+    # GET /passkeys/credentials
+    # パスキー一覧・管理画面
+    def index
+      @credentials = current_user.webauthn_credentials.order(created_at: :desc)
+    end
+
+    # PATCH /passkeys/credentials/:id
+    # パスキーの名前を変更
+    def update
+      if @credential.update(credential_params)
+        respond_to do |format|
+          format.turbo_stream do
+            render turbo_stream: turbo_stream.replace(
+              dom_id(@credential),
+              partial: "passkeys/credentials/credential",
+              locals: { credential: @credential }
+            )
+          end
+          format.html { redirect_to passkeys_credentials_path, notice: "パスキーの名前を変更しました" }
+          format.json { render json: { success: true, credential: credential_json(@credential) } }
+        end
+      else
+        respond_to do |format|
+          format.html { redirect_to passkeys_credentials_path, alert: @credential.errors.full_messages.join(", ") }
+          format.json { render json: { success: false, error: @credential.errors.full_messages.join(", ") }, status: :unprocessable_entity }
+        end
+      end
+    end
+
+    # DELETE /passkeys/credentials/:id
+    # パスキーを削除
+    def destroy
+      @credential.destroy!
+
+      respond_to do |format|
+        format.turbo_stream do
+          render turbo_stream: turbo_stream.remove(dom_id(@credential))
+        end
+        format.html { redirect_to passkeys_credentials_path, notice: "パスキーを削除しました" }
+        format.json { render json: { success: true } }
+      end
+    end
+
+    private
+
+    def ensure_passkey_enabled
+      return if Setting.passkey_enabled?
+
+      redirect_to root_path, alert: "パスキー機能は無効です"
+    end
+
+    def set_credential
+      @credential = current_user.webauthn_credentials.find(params[:id])
+    end
+
+    def credential_params
+      params.require(:webauthn_credential).permit(:nickname)
+    end
+
+    def credential_json(credential)
+      {
+        id: credential.id,
+        nickname: credential.display_name,
+        authenticator_type: credential.authenticator_type_name,
+        created_at: credential.created_at.iso8601,
+        last_used_at: credential.last_used_at&.iso8601
+      }
+    end
+  end
+end

--- a/app/controllers/passkeys/registrations_controller.rb
+++ b/app/controllers/passkeys/registrations_controller.rb
@@ -1,0 +1,75 @@
+module Passkeys
+  class RegistrationsController < ApplicationController
+    before_action :ensure_passkey_enabled
+
+    # GET /passkeys/registrations/new
+    # パスキー登録オプションを取得（JSON）
+    def new
+      ensure_webauthn_id
+
+      options = ::WebAuthn::Credential.options_for_create(
+        user: {
+          id: current_user.webauthn_id,
+          name: current_user.email,
+          display_name: current_user.email
+        },
+        exclude: current_user.webauthn_credentials.pluck(:external_id)
+      )
+
+      session[:webauthn_challenge] = options.challenge
+
+      render json: options
+    end
+
+    # POST /passkeys/registrations
+    # パスキーを登録
+    def create
+      webauthn_credential = ::WebAuthn::Credential.from_create(params[:credential])
+
+      webauthn_credential.verify(session[:webauthn_challenge])
+
+      credential = current_user.webauthn_credentials.create!(
+        external_id: webauthn_credential.id,
+        public_key: webauthn_credential.public_key,
+        sign_count: webauthn_credential.sign_count,
+        authenticator_type: params.dig(:credential, :response, :authenticatorAttachment),
+        nickname: params[:nickname].presence
+      )
+
+      session.delete(:webauthn_challenge)
+
+      render json: { success: true, credential: credential_json(credential) }
+    rescue ::WebAuthn::Error => e
+      render json: { success: false, error: e.message }, status: :unprocessable_entity
+    rescue ActiveRecord::RecordInvalid => e
+      render json: { success: false, error: e.record.errors.full_messages.join(", ") }, status: :unprocessable_entity
+    end
+
+    private
+
+    def ensure_passkey_enabled
+      return if Setting.passkey_enabled?
+
+      respond_to do |format|
+        format.html { redirect_to root_path, alert: "パスキー機能は無効です" }
+        format.json { render json: { error: "パスキー機能は無効です" }, status: :forbidden }
+      end
+    end
+
+    def ensure_webauthn_id
+      return if current_user.webauthn_id.present?
+
+      current_user.update!(webauthn_id: ::WebAuthn.generate_user_id)
+    end
+
+    def credential_json(credential)
+      {
+        id: credential.id,
+        nickname: credential.display_name,
+        authenticator_type: credential.authenticator_type_name,
+        created_at: credential.created_at.iso8601,
+        last_used_at: credential.last_used_at&.iso8601
+      }
+    end
+  end
+end

--- a/app/controllers/passkeys/sessions_controller.rb
+++ b/app/controllers/passkeys/sessions_controller.rb
@@ -1,0 +1,56 @@
+module Passkeys
+  class SessionsController < ApplicationController
+    skip_before_action :authenticate_user!
+    before_action :ensure_passkey_enabled
+
+    # GET /passkeys/sessions/new
+    # パスキー認証オプションを取得（JSON）
+    def new
+      options = ::WebAuthn::Credential.options_for_get(
+        allow: ::WebauthnCredential.pluck(:external_id)
+      )
+
+      session[:webauthn_challenge] = options.challenge
+
+      render json: options
+    end
+
+    # POST /passkeys/sessions
+    # パスキーで認証してログイン
+    def create
+      webauthn_credential = ::WebAuthn::Credential.from_get(params[:credential])
+
+      stored_credential = ::WebauthnCredential.find_by!(external_id: webauthn_credential.id)
+
+      webauthn_credential.verify(
+        session[:webauthn_challenge],
+        public_key: stored_credential.public_key,
+        sign_count: stored_credential.sign_count
+      )
+
+      stored_credential.update_sign_count!(webauthn_credential.sign_count)
+
+      session.delete(:webauthn_challenge)
+
+      # Devise でログイン
+      sign_in(stored_credential.user)
+
+      render json: { success: true, redirect_url: root_path }
+    rescue ::WebAuthn::Error => e
+      render json: { success: false, error: e.message }, status: :unprocessable_entity
+    rescue ActiveRecord::RecordNotFound
+      render json: { success: false, error: "パスキーが見つかりません" }, status: :unprocessable_entity
+    end
+
+    private
+
+    def ensure_passkey_enabled
+      return if Setting.passkey_enabled?
+
+      respond_to do |format|
+        format.html { redirect_to new_user_session_path, alert: "パスキー機能は無効です" }
+        format.json { render json: { error: "パスキー機能は無効です" }, status: :forbidden }
+      end
+    end
+  end
+end

--- a/app/javascript/controllers/credential_edit_controller.js
+++ b/app/javascript/controllers/credential_edit_controller.js
@@ -1,0 +1,24 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["displayName", "editForm", "actions", "input"]
+
+  edit() {
+    this.displayNameTarget.classList.add("d-none")
+    this.actionsTarget.classList.add("d-none")
+    this.editFormTarget.classList.remove("d-none")
+    this.inputTarget.focus()
+    this.inputTarget.select()
+  }
+
+  cancel() {
+    this.editFormTarget.classList.add("d-none")
+    this.displayNameTarget.classList.remove("d-none")
+    this.actionsTarget.classList.remove("d-none")
+  }
+
+  save(event) {
+    // Turbo Streams が処理を行うため、フォーム送信は通常通り
+    // 成功時にパーシャルが再描画される
+  }
+}

--- a/app/javascript/controllers/passkey_login_controller.js
+++ b/app/javascript/controllers/passkey_login_controller.js
@@ -1,0 +1,115 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["button", "result", "message"]
+
+  async login() {
+    this.buttonTarget.disabled = true
+    this.buttonTarget.textContent = "認証中..."
+    this.hideResult()
+
+    try {
+      // 認証オプションを取得
+      const optionsResponse = await fetch("/passkeys/sessions/new", {
+        method: "GET",
+        headers: {
+          "Accept": "application/json",
+          "X-CSRF-Token": this.csrfToken
+        }
+      })
+
+      if (!optionsResponse.ok) {
+        const error = await optionsResponse.json()
+        throw new Error(error.error || "認証オプションの取得に失敗しました")
+      }
+
+      const options = await optionsResponse.json()
+
+      // WebAuthn API で認証
+      const credential = await navigator.credentials.get({
+        publicKey: {
+          ...options,
+          challenge: this.base64UrlToArrayBuffer(options.challenge),
+          allowCredentials: (options.allowCredentials || []).map(cred => ({
+            ...cred,
+            id: this.base64UrlToArrayBuffer(cred.id)
+          }))
+        }
+      })
+
+      // 認証結果をサーバーに送信
+      const authResponse = await fetch("/passkeys/sessions", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Accept": "application/json",
+          "X-CSRF-Token": this.csrfToken
+        },
+        body: JSON.stringify({
+          credential: {
+            id: credential.id,
+            rawId: this.arrayBufferToBase64Url(credential.rawId),
+            type: credential.type,
+            response: {
+              clientDataJSON: this.arrayBufferToBase64Url(credential.response.clientDataJSON),
+              authenticatorData: this.arrayBufferToBase64Url(credential.response.authenticatorData),
+              signature: this.arrayBufferToBase64Url(credential.response.signature),
+              userHandle: credential.response.userHandle ? this.arrayBufferToBase64Url(credential.response.userHandle) : null
+            }
+          }
+        })
+      })
+
+      const result = await authResponse.json()
+
+      if (result.success) {
+        this.showResult("認証成功。リダイレクトします...", "success")
+        window.location.href = result.redirect_url
+      } else {
+        throw new Error(result.error || "認証に失敗しました")
+      }
+    } catch (error) {
+      if (error.name === "NotAllowedError") {
+        this.showResult("認証がキャンセルされました", "warning")
+      } else {
+        this.showResult(error.message, "danger")
+      }
+      this.buttonTarget.disabled = false
+      this.buttonTarget.textContent = "パスキーでログイン"
+    }
+  }
+
+  get csrfToken() {
+    return document.querySelector('meta[name="csrf-token"]').content
+  }
+
+  base64UrlToArrayBuffer(base64url) {
+    const base64 = base64url.replace(/-/g, '+').replace(/_/g, '/')
+    const padding = '='.repeat((4 - base64.length % 4) % 4)
+    const binary = atob(base64 + padding)
+    const bytes = new Uint8Array(binary.length)
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i)
+    }
+    return bytes.buffer
+  }
+
+  arrayBufferToBase64Url(buffer) {
+    const bytes = new Uint8Array(buffer)
+    let binary = ''
+    for (let i = 0; i < bytes.length; i++) {
+      binary += String.fromCharCode(bytes[i])
+    }
+    return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '')
+  }
+
+  showResult(message, type) {
+    this.resultTarget.classList.remove("d-none")
+    this.messageTarget.textContent = message
+    this.messageTarget.className = `alert alert-${type} mb-0`
+  }
+
+  hideResult() {
+    this.resultTarget.classList.add("d-none")
+  }
+}

--- a/app/javascript/controllers/passkey_register_controller.js
+++ b/app/javascript/controllers/passkey_register_controller.js
@@ -1,0 +1,124 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["nickname", "button", "result", "message"]
+
+  async register() {
+    this.buttonTarget.disabled = true
+    this.buttonTarget.textContent = "登録中..."
+    this.hideResult()
+
+    try {
+      // 登録オプションを取得
+      const optionsResponse = await fetch("/passkeys/registrations/new", {
+        method: "GET",
+        headers: {
+          "Accept": "application/json",
+          "X-CSRF-Token": this.csrfToken
+        }
+      })
+
+      if (!optionsResponse.ok) {
+        const error = await optionsResponse.json()
+        throw new Error(error.error || "登録オプションの取得に失敗しました")
+      }
+
+      const options = await optionsResponse.json()
+
+      // WebAuthn API でクレデンシャルを作成
+      const credential = await navigator.credentials.create({
+        publicKey: {
+          ...options,
+          challenge: this.base64UrlToArrayBuffer(options.challenge),
+          user: {
+            ...options.user,
+            id: this.base64UrlToArrayBuffer(options.user.id)
+          },
+          excludeCredentials: (options.excludeCredentials || []).map(cred => ({
+            ...cred,
+            id: this.base64UrlToArrayBuffer(cred.id)
+          }))
+        }
+      })
+
+      // クレデンシャルをサーバーに送信
+      const createResponse = await fetch("/passkeys/registrations", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Accept": "application/json",
+          "X-CSRF-Token": this.csrfToken
+        },
+        body: JSON.stringify({
+          credential: {
+            id: credential.id,
+            rawId: this.arrayBufferToBase64Url(credential.rawId),
+            type: credential.type,
+            response: {
+              clientDataJSON: this.arrayBufferToBase64Url(credential.response.clientDataJSON),
+              attestationObject: this.arrayBufferToBase64Url(credential.response.attestationObject),
+              authenticatorAttachment: credential.authenticatorAttachment
+            }
+          },
+          nickname: this.nicknameTarget.value.trim()
+        })
+      })
+
+      const result = await createResponse.json()
+
+      if (result.success) {
+        this.showResult("パスキーを登録しました", "success")
+        this.nicknameTarget.value = ""
+        // ページをリロードして一覧を更新
+        setTimeout(() => window.location.reload(), 1000)
+      } else {
+        throw new Error(result.error || "登録に失敗しました")
+      }
+    } catch (error) {
+      if (error.name === "NotAllowedError") {
+        this.showResult("登録がキャンセルされました", "warning")
+      } else if (error.name === "InvalidStateError") {
+        this.showResult("このパスキーは既に登録されています", "warning")
+      } else {
+        this.showResult(error.message, "danger")
+      }
+    } finally {
+      this.buttonTarget.disabled = false
+      this.buttonTarget.textContent = "パスキーを登録"
+    }
+  }
+
+  get csrfToken() {
+    return document.querySelector('meta[name="csrf-token"]').content
+  }
+
+  base64UrlToArrayBuffer(base64url) {
+    const base64 = base64url.replace(/-/g, '+').replace(/_/g, '/')
+    const padding = '='.repeat((4 - base64.length % 4) % 4)
+    const binary = atob(base64 + padding)
+    const bytes = new Uint8Array(binary.length)
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i)
+    }
+    return bytes.buffer
+  }
+
+  arrayBufferToBase64Url(buffer) {
+    const bytes = new Uint8Array(buffer)
+    let binary = ''
+    for (let i = 0; i < bytes.length; i++) {
+      binary += String.fromCharCode(bytes[i])
+    }
+    return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '')
+  }
+
+  showResult(message, type) {
+    this.resultTarget.classList.remove("d-none")
+    this.messageTarget.textContent = message
+    this.messageTarget.className = `alert alert-${type} mb-0`
+  }
+
+  hideResult() {
+    this.resultTarget.classList.add("d-none")
+  }
+}

--- a/app/models/forms/passkey_settings_form.rb
+++ b/app/models/forms/passkey_settings_form.rb
@@ -1,0 +1,39 @@
+module Forms
+  class PasskeySettingsForm
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    attribute :enabled, :boolean
+
+    def initialize(attributes = {})
+      super
+      load_from_settings if attributes.empty?
+    end
+
+    def save
+      Setting.passkey_enabled = enabled
+      true
+    rescue => e
+      errors.add(:base, e.message)
+      false
+    end
+
+    def persisted?
+      true
+    end
+
+    def to_key
+      [ :passkey_settings ]
+    end
+
+    def model_name
+      ActiveModel::Name.new(self, nil, "PasskeySettings")
+    end
+
+    private
+
+    def load_from_settings
+      self.enabled = Setting.passkey_enabled
+    end
+  end
+end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -40,6 +40,7 @@ class Setting < RailsSettings::Base
   field :local_auth_enabled, type: :boolean, default: true
   field :local_auth_show_on_login, type: :boolean, default: true
   field :self_signup_enabled, type: :boolean, default: false
+  field :passkey_enabled, type: :boolean, default: false
 
   # === OCR設定 ===
   field :ocr_endpoint, type: :string, default: ""
@@ -90,6 +91,10 @@ class Setting < RailsSettings::Base
 
     def self_signup_enabled?
       self_signup_enabled
+    end
+
+    def passkey_enabled?
+      passkey_enabled
     end
 
     # OCR設定

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,12 +7,19 @@ class User < ApplicationRecord
 
   has_many :images, dependent: :destroy
   has_many :image_groups, dependent: :destroy
+  has_many :webauthn_credentials, dependent: :destroy
+
+  before_create :generate_webauthn_id
 
   def self.from_omniauth(auth)
     # メールアドレスで既存ユーザーを検索、なければ作成
     where(email: auth.info.email).first_or_create do |user|
       user.password = Devise.friendly_token[0, 20]
     end
+  end
+
+  def passkey_registered?
+    webauthn_credentials.exists?
   end
 
   # ストレージ使用量（バイト）
@@ -38,5 +45,11 @@ class User < ApplicationRecord
   # 残り容量（MB）
   def available_storage_mb
     available_storage_bytes / 1.megabyte.to_f
+  end
+
+  private
+
+  def generate_webauthn_id
+    self.webauthn_id ||= WebAuthn.generate_user_id
   end
 end

--- a/app/models/webauthn_credential.rb
+++ b/app/models/webauthn_credential.rb
@@ -1,0 +1,30 @@
+class WebauthnCredential < ApplicationRecord
+  belongs_to :user
+
+  validates :external_id, presence: true, uniqueness: true
+  validates :public_key, presence: true
+  validates :sign_count, numericality: { greater_than_or_equal_to: 0 }
+
+  AUTHENTICATOR_TYPES = %w[platform cross-platform].freeze
+
+  validates :authenticator_type, inclusion: { in: AUTHENTICATOR_TYPES }, allow_nil: true
+
+  def update_sign_count!(new_sign_count)
+    update!(sign_count: new_sign_count, last_used_at: Time.current)
+  end
+
+  def display_name
+    nickname.presence || "パスキー #{id}"
+  end
+
+  def authenticator_type_name
+    case authenticator_type
+    when "platform"
+      "組み込み認証器"
+    when "cross-platform"
+      "セキュリティキー"
+    else
+      "不明"
+    end
+  end
+end

--- a/app/views/admin/settings/show.html.erb
+++ b/app/views/admin/settings/show.html.erb
@@ -35,22 +35,52 @@
             <%= f.label :local_auth_show_on_login, "ログイン画面にローカル認証フォームを表示", class: "form-check-label" %>
           </div>
 
-          <div class="form-check mb-4">
+          <div class="form-check mb-3">
             <%= f.check_box :self_signup_enabled, class: "form-check-input" %>
             <%= f.label :self_signup_enabled, "新規登録を許可する", class: "form-check-label" %>
           </div>
-
-          <h6 class="text-muted mb-3">外部 IdP</h6>
-          <p class="card-text mb-3">
-            登録済み IdP: <span class="badge bg-secondary"><%= IdentityProvider.count %> 件</span>
-            （有効: <span class="badge bg-success"><%= IdentityProvider.enabled.count %> 件</span>）
-          </p>
-          <%= link_to "IdP 設定を管理", admin_identity_providers_path, class: "btn btn-outline-primary btn-sm mb-3" %>
 
           <div class="d-grid gap-2 d-md-flex justify-content-md-end">
             <%= f.submit "保存", class: "btn btn-primary" %>
           </div>
         <% end %>
+
+        <hr class="my-4">
+
+        <h6 class="text-muted mb-3">パスキー</h6>
+        <div id="flash_passkey"></div>
+        <%= form_with model: @passkey_form, url: update_passkey_admin_settings_path, method: :patch do |f| %>
+          <% if @passkey_form.errors.any? %>
+            <div class="alert alert-danger">
+              <ul class="mb-0">
+                <% @passkey_form.errors.full_messages.each do |message| %>
+                  <li><%= message %></li>
+                <% end %>
+              </ul>
+            </div>
+          <% end %>
+
+          <div class="form-check mb-3">
+            <%= f.check_box :enabled, class: "form-check-input" %>
+            <%= f.label :enabled, "パスキー認証を有効にする", class: "form-check-label" %>
+          </div>
+          <p class="text-muted small mb-3">
+            有効にすると、ユーザーはパスキー（WebAuthn）を登録してログインに使用できます。
+          </p>
+
+          <div class="d-grid gap-2 d-md-flex justify-content-md-end">
+            <%= f.submit "保存", class: "btn btn-primary" %>
+          </div>
+        <% end %>
+
+        <hr class="my-4">
+
+        <h6 class="text-muted mb-3">外部 IdP</h6>
+        <p class="card-text mb-3">
+          登録済み IdP: <span class="badge bg-secondary"><%= IdentityProvider.count %> 件</span>
+          （有効: <span class="badge bg-success"><%= IdentityProvider.enabled.count %> 件</span>）
+        </p>
+        <%= link_to "IdP 設定を管理", admin_identity_providers_path, class: "btn btn-outline-primary btn-sm" %>
       </div>
     </div>
   </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -54,7 +54,27 @@
           </div>
         <% end %>
 
-        <% unless Setting.local_auth_show_on_login? || visible_idps.any? %>
+        <% if Setting.passkey_enabled? && WebauthnCredential.exists? %>
+          <% has_other_methods = (Setting.local_auth_enabled? && Setting.local_auth_show_on_login?) || visible_idps.any? %>
+          <% if has_other_methods %>
+            <hr>
+          <% end %>
+          <div data-controller="passkey-login">
+            <h5 class="card-title">パスキーでログイン</h5>
+            <div class="d-grid">
+              <button type="button" class="btn btn-outline-primary"
+                      data-action="click->passkey-login#login"
+                      data-passkey-login-target="button">
+                パスキーでログイン
+              </button>
+            </div>
+            <div class="d-none mt-3" data-passkey-login-target="result">
+              <div class="alert mb-0" data-passkey-login-target="message"></div>
+            </div>
+          </div>
+        <% end %>
+
+        <% unless Setting.local_auth_show_on_login? || visible_idps.any? || (Setting.passkey_enabled? && WebauthnCredential.exists?) %>
           <div class="alert alert-warning">
             利用可能なログイン方法がありません。管理者に連絡してください。
           </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -65,6 +65,12 @@
                   <%= current_user.name.presence || current_user.email %>
                 </a>
                 <ul class="dropdown-menu dropdown-menu-end">
+                  <% if Setting.passkey_enabled? %>
+                    <li>
+                      <%= link_to "パスキー管理", passkeys_credentials_path, class: "dropdown-item" %>
+                    </li>
+                    <li><hr class="dropdown-divider"></li>
+                  <% end %>
                   <li>
                     <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete }, class: "dropdown-item" %>
                   </li>

--- a/app/views/passkeys/credentials/_credential.html.erb
+++ b/app/views/passkeys/credentials/_credential.html.erb
@@ -1,0 +1,42 @@
+<%= tag.li id: dom_id(credential), class: "list-group-item", data: { controller: "credential-edit" } do %>
+  <div class="d-flex justify-content-between align-items-start">
+    <div class="flex-grow-1">
+      <div class="d-flex align-items-center mb-1">
+        <strong data-credential-edit-target="displayName"><%= credential.display_name %></strong>
+        <span class="badge bg-secondary ms-2"><%= credential.authenticator_type_name %></span>
+      </div>
+
+      <div class="small text-muted">
+        <span>登録日: <%= l(credential.created_at, format: :short) %></span>
+        <% if credential.last_used_at %>
+          <span class="ms-3">最終使用: <%= l(credential.last_used_at, format: :short) %></span>
+        <% end %>
+      </div>
+
+      <%# 編集フォーム（非表示） %>
+      <div class="d-none mt-2" data-credential-edit-target="editForm">
+        <%= form_with model: credential, url: passkeys_credential_path(credential), method: :patch, local: false, data: { action: "submit->credential-edit#save" } do |f| %>
+          <div class="input-group" style="max-width: 300px;">
+            <%= f.text_field :nickname, class: "form-control form-control-sm", placeholder: "パスキーの名前", value: credential.nickname, data: { credential_edit_target: "input" } %>
+            <button type="submit" class="btn btn-sm btn-primary">保存</button>
+            <button type="button" class="btn btn-sm btn-outline-secondary" data-action="click->credential-edit#cancel">キャンセル</button>
+          </div>
+        <% end %>
+      </div>
+    </div>
+
+    <div class="btn-group btn-group-sm" data-credential-edit-target="actions">
+      <button type="button" class="btn btn-outline-secondary" data-action="click->credential-edit#edit" title="名前を変更">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-pencil" viewBox="0 0 16 16">
+          <path d="M12.146.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1 0 .708l-10 10a.5.5 0 0 1-.168.11l-5 2a.5.5 0 0 1-.65-.65l2-5a.5.5 0 0 1 .11-.168zM11.207 2.5 13.5 4.793 14.793 3.5 12.5 1.207zm1.586 3L10.5 3.207 4 9.707V10h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.293zm-9.761 5.175-.106.106-1.528 3.821 3.821-1.528.106-.106A.5.5 0 0 1 5 12.5V12h-.5a.5.5 0 0 1-.5-.5V11h-.5a.5.5 0 0 1-.468-.325"/>
+        </svg>
+      </button>
+      <%= button_to passkeys_credential_path(credential), method: :delete, form: { data: { turbo_confirm: "このパスキーを削除しますか？" } }, class: "btn btn-outline-danger", title: "削除" do %>
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-trash" viewBox="0 0 16 16">
+          <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0z"/>
+          <path d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4zM2.5 3h11V2h-11z"/>
+        </svg>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/passkeys/credentials/index.html.erb
+++ b/app/views/passkeys/credentials/index.html.erb
@@ -1,0 +1,57 @@
+<div class="d-flex justify-content-between align-items-center mb-4">
+  <h1>パスキー管理</h1>
+</div>
+
+<div class="card mb-4">
+  <div class="card-header">
+    <h5 class="mb-0">パスキーを登録</h5>
+  </div>
+  <div class="card-body" data-controller="passkey-register">
+    <p class="card-text text-muted">
+      パスキーを登録すると、パスワードなしでログインできます。
+      デバイスの生体認証（指紋、顔認証）やセキュリティキーを使用します。
+    </p>
+
+    <div class="mb-3">
+      <label for="passkey_nickname" class="form-label">パスキーの名前（任意）</label>
+      <input type="text" class="form-control" id="passkey_nickname"
+             data-passkey-register-target="nickname"
+             placeholder="例: MacBook Pro, iPhone 15"
+             style="max-width: 300px;">
+      <div class="form-text">識別しやすい名前を付けると管理が楽になります</div>
+    </div>
+
+    <button type="button" class="btn btn-primary"
+            data-action="click->passkey-register#register"
+            data-passkey-register-target="button">
+      パスキーを登録
+    </button>
+
+    <div class="d-none mt-3" data-passkey-register-target="result">
+      <div class="alert" data-passkey-register-target="message"></div>
+    </div>
+  </div>
+</div>
+
+<div class="card">
+  <div class="card-header d-flex justify-content-between align-items-center">
+    <h5 class="mb-0">登録済みパスキー</h5>
+    <span class="badge bg-secondary"><%= @credentials.count %> 件</span>
+  </div>
+
+  <% if @credentials.any? %>
+    <ul class="list-group list-group-flush" id="credentials-list">
+      <% @credentials.each do |credential| %>
+        <%= render partial: "credential", locals: { credential: credential } %>
+      <% end %>
+    </ul>
+  <% else %>
+    <div class="card-body text-center text-muted py-5">
+      <p class="mb-0">登録されたパスキーはありません</p>
+    </div>
+  <% end %>
+</div>
+
+<div class="mt-4">
+  <%= link_to "← 戻る", root_path, class: "text-decoration-none" %>
+</div>

--- a/config/initializers/webauthn.rb
+++ b/config/initializers/webauthn.rb
@@ -1,0 +1,5 @@
+WebAuthn.configure do |config|
+  config.allowed_origins = [ ENV.fetch("WEBAUTHN_ORIGIN") { "http://localhost:3000" } ]
+  config.rp_name = "kulip"
+  # rp_id は origin から自動推論される
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
     end
     resource :settings, only: [ :show ] do
       patch :update_auth, on: :member
+      patch :update_passkey, on: :member
       patch :update_ocr, on: :member
       patch :update_quota, on: :member
       patch :update_retention, on: :member
@@ -51,6 +52,13 @@ Rails.application.routes.draw do
       end
     end
     resources :images, only: %i[index destroy]
+  end
+
+  # パスキー
+  namespace :passkeys do
+    resources :registrations, only: %i[new create]
+    resources :sessions, only: %i[new create]
+    resources :credentials, only: %i[index update destroy]
   end
 
   # SAML SP メタデータ

--- a/db/migrate/20260330210851_create_webauthn_credentials.rb
+++ b/db/migrate/20260330210851_create_webauthn_credentials.rb
@@ -1,0 +1,16 @@
+class CreateWebauthnCredentials < ActiveRecord::Migration[8.1]
+  def change
+    create_table :webauthn_credentials do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :external_id, null: false
+      t.string :public_key, null: false
+      t.string :nickname
+      t.bigint :sign_count, null: false, default: 0
+      t.string :authenticator_type
+      t.datetime :last_used_at
+      t.timestamps
+
+      t.index :external_id, unique: true
+    end
+  end
+end

--- a/db/migrate/20260330210902_add_webauthn_id_to_users.rb
+++ b/db/migrate/20260330210902_add_webauthn_id_to_users.rb
@@ -1,0 +1,6 @@
+class AddWebauthnIdToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :webauthn_id, :string
+    add_index :users, :webauthn_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_21_112804) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_30_210902) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -121,8 +121,24 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_21_112804) do
     t.datetime "reset_password_sent_at"
     t.string "reset_password_token"
     t.datetime "updated_at", null: false
+    t.string "webauthn_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["webauthn_id"], name: "index_users_on_webauthn_id", unique: true
+  end
+
+  create_table "webauthn_credentials", force: :cascade do |t|
+    t.string "authenticator_type"
+    t.datetime "created_at", null: false
+    t.string "external_id", null: false
+    t.datetime "last_used_at"
+    t.string "nickname"
+    t.string "public_key", null: false
+    t.bigint "sign_count", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+    t.index ["external_id"], name: "index_webauthn_credentials_on_external_id", unique: true
+    t.index ["user_id"], name: "index_webauthn_credentials_on_user_id"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
@@ -130,4 +146,5 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_21_112804) do
   add_foreign_key "image_groups", "users"
   add_foreign_key "images", "image_groups"
   add_foreign_key "images", "users"
+  add_foreign_key "webauthn_credentials", "users"
 end

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -387,5 +387,40 @@ module Admin
 
       assert_redirected_to root_path
     end
+
+    # Passkey settings tests
+    test "update_passkey enables passkey" do
+      sign_in @admin
+      Setting.passkey_enabled = false
+
+      patch update_passkey_admin_settings_path, params: {
+        passkey_settings: { enabled: true }
+      }
+
+      assert_redirected_to admin_settings_path(anchor: "collapseAuth")
+      assert Setting.passkey_enabled?
+    end
+
+    test "update_passkey disables passkey" do
+      sign_in @admin
+      Setting.passkey_enabled = true
+
+      patch update_passkey_admin_settings_path, params: {
+        passkey_settings: { enabled: false }
+      }
+
+      assert_redirected_to admin_settings_path(anchor: "collapseAuth")
+      assert_not Setting.passkey_enabled?
+    end
+
+    test "update_passkey requires admin" do
+      sign_in @user
+
+      patch update_passkey_admin_settings_path, params: {
+        passkey_settings: { enabled: true }
+      }
+
+      assert_redirected_to root_path
+    end
   end
 end

--- a/test/controllers/passkeys/credentials_controller_test.rb
+++ b/test/controllers/passkeys/credentials_controller_test.rb
@@ -1,0 +1,106 @@
+require "test_helper"
+
+module Passkeys
+  class CredentialsControllerTest < ActionDispatch::IntegrationTest
+    setup do
+      @user = users(:user)
+      @other_user = users(:admin)
+      @credential = webauthn_credentials(:one)
+      Setting.passkey_enabled = true
+    end
+
+    teardown do
+      Setting.passkey_enabled = false
+    end
+
+    test "index requires authentication" do
+      get passkeys_credentials_path
+      assert_redirected_to new_user_session_path
+    end
+
+    test "index redirects when passkey disabled" do
+      Setting.passkey_enabled = false
+      sign_in @user
+      get passkeys_credentials_path
+      assert_redirected_to root_path
+      assert_equal "パスキー機能は無効です", flash[:alert]
+    end
+
+    test "index displays credentials list" do
+      sign_in @user
+      get passkeys_credentials_path
+      assert_response :success
+      assert_select "h1", "パスキー管理"
+      assert_select "#credentials-list li", count: 2
+    end
+
+    test "update changes credential nickname" do
+      sign_in @user
+      patch passkeys_credential_path(@credential), params: {
+        webauthn_credential: { nickname: "New Name" }
+      }
+      assert_redirected_to passkeys_credentials_path
+      assert_equal "New Name", @credential.reload.nickname
+    end
+
+    test "update with turbo_stream" do
+      sign_in @user
+      patch passkeys_credential_path(@credential), params: {
+        webauthn_credential: { nickname: "New Name" }
+      }, as: :turbo_stream
+      assert_response :success
+      assert_equal "New Name", @credential.reload.nickname
+    end
+
+    test "update with json" do
+      sign_in @user
+      patch passkeys_credential_path(@credential), params: {
+        webauthn_credential: { nickname: "New Name" }
+      }, as: :json
+      assert_response :success
+      json = JSON.parse(response.body)
+      assert json["success"]
+      assert_equal "New Name", json["credential"]["nickname"]
+    end
+
+    test "update rejects other user's credential" do
+      sign_in @other_user
+      patch passkeys_credential_path(@credential), params: {
+        webauthn_credential: { nickname: "Hacked" }
+      }
+      assert_response :not_found
+    end
+
+    test "destroy deletes credential" do
+      sign_in @user
+      assert_difference("WebauthnCredential.count", -1) do
+        delete passkeys_credential_path(@credential)
+      end
+      assert_redirected_to passkeys_credentials_path
+    end
+
+    test "destroy with turbo_stream" do
+      sign_in @user
+      assert_difference("WebauthnCredential.count", -1) do
+        delete passkeys_credential_path(@credential), as: :turbo_stream
+      end
+      assert_response :success
+    end
+
+    test "destroy with json" do
+      sign_in @user
+      assert_difference("WebauthnCredential.count", -1) do
+        delete passkeys_credential_path(@credential), as: :json
+      end
+      assert_response :success
+      json = JSON.parse(response.body)
+      assert json["success"]
+    end
+
+    test "destroy rejects other user's credential" do
+      sign_in @other_user
+      delete passkeys_credential_path(@credential)
+      assert_response :not_found
+    end
+  end
+end

--- a/test/controllers/passkeys/registrations_controller_test.rb
+++ b/test/controllers/passkeys/registrations_controller_test.rb
@@ -1,0 +1,69 @@
+require "test_helper"
+
+module Passkeys
+  class RegistrationsControllerTest < ActionDispatch::IntegrationTest
+    setup do
+      @user = users(:user)
+      Setting.passkey_enabled = true
+    end
+
+    teardown do
+      Setting.passkey_enabled = false
+    end
+
+    test "new requires authentication" do
+      get new_passkeys_registration_path, as: :json
+      assert_response :unauthorized
+    end
+
+    test "new redirects when passkey disabled for HTML" do
+      Setting.passkey_enabled = false
+      sign_in @user
+      get new_passkeys_registration_path
+      assert_redirected_to root_path
+      assert_equal "パスキー機能は無効です", flash[:alert]
+    end
+
+    test "new returns forbidden when passkey disabled for JSON" do
+      Setting.passkey_enabled = false
+      sign_in @user
+      get new_passkeys_registration_path, as: :json
+      assert_response :forbidden
+      json = JSON.parse(response.body)
+      assert_equal "パスキー機能は無効です", json["error"]
+    end
+
+    test "new returns registration options" do
+      sign_in @user
+      get new_passkeys_registration_path, as: :json
+      assert_response :success
+      json = JSON.parse(response.body)
+      assert json["challenge"].present?
+      assert json["user"].present?
+      assert_equal @user.email, json["user"]["name"]
+    end
+
+    test "new stores challenge in session" do
+      sign_in @user
+      get new_passkeys_registration_path, as: :json
+      assert_response :success
+      # セッションにチャレンジが保存されていることを確認
+      # (セッションは直接確認できないため、次のリクエストで使用されることを想定)
+    end
+
+    test "create requires authentication" do
+      post passkeys_registrations_path, as: :json
+      assert_response :unauthorized
+    end
+
+    test "create returns forbidden when passkey disabled" do
+      Setting.passkey_enabled = false
+      sign_in @user
+      post passkeys_registrations_path, params: { credential: {} }, as: :json
+      assert_response :forbidden
+    end
+
+    # Note: Full registration flow testing requires WebAuthn credential mocking
+    # which is complex. These tests cover the basic authentication and feature flag checks.
+  end
+end

--- a/test/controllers/passkeys/sessions_controller_test.rb
+++ b/test/controllers/passkeys/sessions_controller_test.rb
@@ -1,0 +1,53 @@
+require "test_helper"
+
+module Passkeys
+  class SessionsControllerTest < ActionDispatch::IntegrationTest
+    setup do
+      @user = users(:user)
+      @credential = webauthn_credentials(:one)
+      Setting.passkey_enabled = true
+    end
+
+    teardown do
+      Setting.passkey_enabled = false
+    end
+
+    test "new redirects when passkey disabled for HTML" do
+      Setting.passkey_enabled = false
+      get new_passkeys_session_path
+      assert_redirected_to new_user_session_path
+      assert_equal "パスキー機能は無効です", flash[:alert]
+    end
+
+    test "new returns forbidden when passkey disabled for JSON" do
+      Setting.passkey_enabled = false
+      get new_passkeys_session_path, as: :json
+      assert_response :forbidden
+      json = JSON.parse(response.body)
+      assert_equal "パスキー機能は無効です", json["error"]
+    end
+
+    test "new returns authentication options" do
+      get new_passkeys_session_path, as: :json
+      assert_response :success
+      json = JSON.parse(response.body)
+      assert json["challenge"].present?
+      assert json["allowCredentials"].present?
+    end
+
+    test "new stores challenge in session" do
+      get new_passkeys_session_path, as: :json
+      assert_response :success
+      # セッションにチャレンジが保存されていることを確認
+    end
+
+    test "create returns forbidden when passkey disabled" do
+      Setting.passkey_enabled = false
+      post passkeys_sessions_path, params: { credential: {} }, as: :json
+      assert_response :forbidden
+    end
+
+    # Note: Full authentication flow testing requires WebAuthn credential mocking
+    # which is complex. These tests cover the basic feature flag checks.
+  end
+end

--- a/test/controllers/setup_controller_test.rb
+++ b/test/controllers/setup_controller_test.rb
@@ -4,6 +4,7 @@ class SetupControllerTest < ActionDispatch::IntegrationTest
   def clear_all_users
     Image.delete_all
     ImageGroup.delete_all
+    WebauthnCredential.delete_all
     User.delete_all
   end
 

--- a/test/fixtures/webauthn_credentials.yml
+++ b/test/fixtures/webauthn_credentials.yml
@@ -1,0 +1,33 @@
+# == Schema Information
+#
+# Table name: webauthn_credentials
+#
+#  id                 :bigint           not null, primary key
+#  user_id            :bigint           not null
+#  external_id        :string           not null
+#  public_key         :string           not null
+#  nickname           :string
+#  sign_count         :bigint           default(0), not null
+#  authenticator_type :string
+#  last_used_at       :datetime
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#
+
+one:
+  user: user
+  external_id: test-credential-id-1
+  public_key: test-public-key-1
+  nickname: MacBook Pro
+  sign_count: 5
+  authenticator_type: platform
+  last_used_at: <%= 1.day.ago.to_fs(:db) %>
+
+two:
+  user: user
+  external_id: test-credential-id-2
+  public_key: test-public-key-2
+  nickname: YubiKey
+  sign_count: 10
+  authenticator_type: cross-platform
+  last_used_at: <%= 1.hour.ago.to_fs(:db) %>

--- a/test/models/webauthn_credential_test.rb
+++ b/test/models/webauthn_credential_test.rb
@@ -1,0 +1,82 @@
+require "test_helper"
+
+class WebauthnCredentialTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:user)
+    @credential = webauthn_credentials(:one)
+  end
+
+  test "belongs to user" do
+    assert_equal @user, @credential.user
+  end
+
+  test "validates presence of external_id" do
+    credential = WebauthnCredential.new(user: @user, public_key: "test")
+    assert_not credential.valid?
+    assert credential.errors[:external_id].any?
+  end
+
+  test "validates uniqueness of external_id" do
+    credential = WebauthnCredential.new(
+      user: @user,
+      external_id: @credential.external_id,
+      public_key: "test"
+    )
+    assert_not credential.valid?
+    assert credential.errors[:external_id].any?
+  end
+
+  test "validates presence of public_key" do
+    credential = WebauthnCredential.new(user: @user, external_id: "unique-id")
+    assert_not credential.valid?
+    assert credential.errors[:public_key].any?
+  end
+
+  test "validates sign_count is not negative" do
+    @credential.sign_count = -1
+    assert_not @credential.valid?
+  end
+
+  test "validates authenticator_type inclusion" do
+    @credential.authenticator_type = "invalid"
+    assert_not @credential.valid?
+    assert @credential.errors[:authenticator_type].any?
+  end
+
+  test "allows nil authenticator_type" do
+    @credential.authenticator_type = nil
+    assert @credential.valid?
+  end
+
+  test "update_sign_count! updates sign_count and last_used_at" do
+    freeze_time do
+      @credential.update_sign_count!(100)
+      assert_equal 100, @credential.sign_count
+      assert_equal Time.current, @credential.last_used_at
+    end
+  end
+
+  test "display_name returns nickname if present" do
+    assert_equal "MacBook Pro", @credential.display_name
+  end
+
+  test "display_name returns default name if nickname is blank" do
+    @credential.nickname = nil
+    assert_equal "パスキー #{@credential.id}", @credential.display_name
+  end
+
+  test "authenticator_type_name returns 組み込み認証器 for platform" do
+    @credential.authenticator_type = "platform"
+    assert_equal "組み込み認証器", @credential.authenticator_type_name
+  end
+
+  test "authenticator_type_name returns セキュリティキー for cross-platform" do
+    @credential.authenticator_type = "cross-platform"
+    assert_equal "セキュリティキー", @credential.authenticator_type_name
+  end
+
+  test "authenticator_type_name returns 不明 for nil" do
+    @credential.authenticator_type = nil
+    assert_equal "不明", @credential.authenticator_type_name
+  end
+end


### PR DESCRIPTION
## Summary

- Passkey (WebAuthn) 認証機能を追加
- webauthn gem を使用してパスキー登録・認証を実装
- 管理者設定でパスキー機能の有効/無効を切り替え可能

## 主な変更

- **webauthn gem** を追加
- **WebauthnCredential モデル** を作成（パスキー情報を保存）
- **パスキー登録・認証・管理用コントローラー** を追加
  - `Passkeys::RegistrationsController` - 登録
  - `Passkeys::SessionsController` - 認証
  - `Passkeys::CredentialsController` - 管理
- **パスキー管理画面** を追加（登録、削除、名前変更）
- **ログイン画面** にパスキーログインボタンを追加
- **管理者設定** にパスキー有効/無効設定を追加

## Test plan

- [x] 管理者設定でパスキーを有効化できることを確認
- [x] パスキー管理画面でパスキーを登録できることを確認
- [x] ログアウト後、パスキーでログインできることを確認
- [x] パスキーの名前変更、削除ができることを確認
- [x] `bin/rails test` で全テスト通過

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)