### PR TITLE
SAML SP EntityID をシステム全体の設定に変更

### DIFF
--- a/app/controllers/admin/identity_providers_controller.rb
+++ b/app/controllers/admin/identity_providers_controller.rb
@@ -1,7 +1,7 @@
 module Admin
   class IdentityProvidersController < BaseController
     # プロバイダータイプごとの許可される settings キー
-    SAML_SETTINGS_KEYS = %w[idp_sso_url idp_slo_url idp_cert sp_entity_id].freeze
+    SAML_SETTINGS_KEYS = %w[idp_sso_url idp_slo_url idp_cert].freeze
     OIDC_SETTINGS_KEYS = %w[issuer client_id client_secret redirect_uri].freeze
 
     before_action :set_identity_provider, only: %i[show edit update destroy]
@@ -80,6 +80,12 @@ module Admin
 
       redirect_to admin_identity_providers_path,
         notice: "アプリを再起動中です。3秒後に自動でリロードします。"
+    end
+
+    def update_saml_sp_entity_id
+      Setting.saml_sp_entity_id = params[:saml_sp_entity_id].to_s.strip
+      redirect_to admin_identity_providers_path,
+        notice: "SP エンティティ ID を更新しました。設定を反映するにはアプリを再起動してください。"
     end
 
     private

--- a/app/controllers/saml_metadata_controller.rb
+++ b/app/controllers/saml_metadata_controller.rb
@@ -27,9 +27,7 @@ class SamlMetadataController < ApplicationController
   end
 
   def sp_entity_id
-    # 登録済み SAML IdP の sp_entity_id を取得、なければデフォルト
-    saml_idp = IdentityProvider.where(provider_type: "saml").first
-    saml_idp&.settings&.dig("sp_entity_id").presence || request.base_url
+    Setting.effective_saml_sp_entity_id(request.base_url)
   end
 
   def assertion_consumer_service_url

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -78,6 +78,9 @@ class Setting < RailsSettings::Base
   # === タイムゾーン設定 ===
   field :timezone, type: :string, default: "Asia/Tokyo"
 
+  # === SAML SP 設定 ===
+  field :saml_sp_entity_id, type: :string, default: ""
+
   # === 互換性メソッド ===
   class << self
     # 認証設定
@@ -185,6 +188,11 @@ class Setting < RailsSettings::Base
     def effective_timezone
       tz = timezone
       tz.present? ? tz : DEFAULT_TIMEZONE
+    end
+
+    # SAML SP 設定
+    def effective_saml_sp_entity_id(fallback = nil)
+      saml_sp_entity_id.presence || fallback || "kulip"
     end
   end
 end

--- a/app/views/admin/identity_providers/_form.html.erb
+++ b/app/views/admin/identity_providers/_form.html.erb
@@ -100,13 +100,6 @@
           id: "settings_idp_cert", rows: 10, class: "form-control font-monospace" %>
     </div>
 
-    <div class="mb-3">
-      <%= label_tag "settings_sp_entity_id", "SP エンティティ ID", class: "form-label" %>
-      <%= text_field_tag "identity_provider[settings][sp_entity_id]",
-          @identity_provider.settings&.dig("sp_entity_id") || "kulip",
-          id: "settings_sp_entity_id", class: "form-control" %>
-    </div>
-
   <% elsif @identity_provider.provider_type == "oidc" %>
     <div class="mb-3">
       <%= label_tag "settings_issuer", "Issuer URL", class: "form-label" %>

--- a/app/views/admin/identity_providers/index.html.erb
+++ b/app/views/admin/identity_providers/index.html.erb
@@ -9,9 +9,25 @@
 <%# SAML SP メタデータ %>
 <div class="card mb-4">
   <div class="card-header">
-    SAML SP メタデータ
+    SAML SP 設定
   </div>
   <div class="card-body">
+    <%= form_with url: update_saml_sp_entity_id_admin_identity_providers_path, method: :patch, local: true, class: "mb-4" do %>
+      <div class="mb-3">
+        <label for="saml_sp_entity_id" class="form-label">SP エンティティ ID</label>
+        <div class="input-group">
+          <input type="text" class="form-control" name="saml_sp_entity_id" id="saml_sp_entity_id"
+                 value="<%= Setting.saml_sp_entity_id.presence || 'kulip' %>"
+                 placeholder="kulip">
+          <button type="submit" class="btn btn-primary">保存</button>
+        </div>
+        <div class="form-text">IdP に登録する SP のエンティティ ID（識別子）を設定します</div>
+      </div>
+    <% end %>
+
+    <hr>
+
+    <h6 class="text-muted mb-3">SP メタデータ</h6>
     <p class="card-text text-muted">IdP に本システムを SP として登録する際に、このメタデータ URL または XML ファイルを使用してください。</p>
     <div class="mb-3">
       <label class="form-label">メタデータ URL</label>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -281,6 +281,17 @@ Devise.setup do |config|
     connection = ActiveRecord::Base.connection
     if connection.table_exists?("identity_providers")
       # モデルを使わず直接SQLで読み込む（初期化時のロード順序問題を回避）
+
+      # SP EntityID を settings テーブルから取得
+      sp_entity_id = "kulip"
+      if connection.table_exists?("settings")
+        result = connection.execute("SELECT value FROM settings WHERE var = 'saml_sp_entity_id' LIMIT 1")
+        if result.any?
+          stored_value = result.first["value"]
+          sp_entity_id = stored_value if stored_value.present?
+        end
+      end
+
       rows = connection.execute("SELECT slug, provider_type, settings FROM identity_providers WHERE enabled = TRUE")
       rows.each do |row|
         slug = row["slug"]
@@ -295,7 +306,7 @@ Devise.setup do |config|
             idp_slo_service_url: settings["idp_slo_url"],
             idp_sso_service_binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
             idp_cert: settings["idp_cert"],
-            sp_entity_id: settings["sp_entity_id"] || "kulip",
+            sp_entity_id: sp_entity_id,
             name_identifier_format: "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
             attribute_statements: {
               email: [ "email", "mail", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress" ]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,7 @@ Rails.application.routes.draw do
       collection do
         post :restart_app
         post :parse_saml_metadata
+        patch :update_saml_sp_entity_id
       end
     end
     resource :settings, only: [ :show ] do


### PR DESCRIPTION
## Summary

- SAML SP EntityID を IdP ごとの設定からシステム全体の設定に変更
- IdP 一覧ページの「SAML SP 設定」カードで EntityID を設定可能に
- SP メタデータダウンロードの近くで設定できるようにユーザビリティを改善

## Test plan

- [ ] 管理者画面の IdP 設定ページで SP EntityID を設定できることを確認
- [ ] 設定した EntityID が SAML メタデータに反映されることを確認
- [ ] アプリ再起動後も設定が保持されることを確認

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)