### PR TITLE
セッション管理・OCRプロンプトパターン・ダウンロードボタン改善

### DIFF
--- a/app/views/image_groups/new.html.erb
+++ b/app/views/image_groups/new.html.erb
@@ -15,26 +15,6 @@
 <div class="card">
   <div class="card-body dropzone" data-controller="dropzone">
     <%= form_with url: image_groups_path, method: :post, multipart: true do |f| %>
-      <div class="mb-3">
-        <label for="memo" class="form-label">メモ（省略可）</label>
-        <%= text_field_tag :memo, nil, placeholder: "任意のメモを入力できます", class: "form-control" %>
-      </div>
-
-      <% if OcrPromptPattern.any? %>
-        <div class="mb-3">
-          <label for="ocr_prompt_pattern_id" class="form-label">プロンプトパターン</label>
-          <%= select_tag :ocr_prompt_pattern_id,
-              options_from_collection_for_select(
-                OcrPromptPattern.ordered,
-                :id,
-                :name,
-                OcrPromptPattern.default_or_first&.id
-              ),
-              class: "form-select",
-              style: "max-width: 400px;" %>
-          <div class="form-text">OCR 処理に使用するプロンプトを選択してください。</div>
-        </div>
-      <% end %>
 
       <div class="mb-3">
         <label for="images" class="form-label">ファイル（複数選択可）</label>
@@ -42,8 +22,28 @@
           <p class="mb-2 text-muted">ここにファイルをドラッグ&ドロップ</p>
           <p class="mb-2 text-muted">または</p>
           <%= file_field_tag "images[]", multiple: true, accept: "image/*,.heic,.heif,application/pdf", class: "form-control", data: { dropzone_target: "input", action: "change->dropzone#onChange" } %>
-          <p class="mt-2 mb-0 text-muted small" data-dropzone-target="label">JPEG, PNG, GIF, HEIC 等の画像ファイル、または PDF ファイルをアップロードできます（PDF は最大 <%= Setting.effective_pdf_max_pages %> ページまで）</p>
+          <p class="mt-2 mb-0 text-muted small" data-dropzone-target="label">JPEG, PNG, GIF, HEIC 等の画像ファイル、または PDF ファイルをアップロードできます。PDF は最大 <%= Setting.effective_pdf_max_pages %> ページまで。</p>
         </div>
+      </div>
+
+      <% if OcrPromptPattern.any? %>
+        <div class="mb-3">
+          <label for="ocr_prompt_pattern_id" class="form-label">処理方法</label>
+          <%= select_tag :ocr_prompt_pattern_id,
+                         options_from_collection_for_select(
+                           OcrPromptPattern.ordered,
+                           :id,
+                           :name,
+                           OcrPromptPattern.default_or_first&.id
+                         ),
+                         class: "form-select",
+                         style: "max-width: 400px;" %>
+        </div>
+      <% end %>
+
+      <div class="mb-3">
+        <label for="memo" class="form-label">メモ（省略可）</label>
+        <%= text_field_tag :memo, nil, placeholder: "任意のメモを入力できます", class: "form-control" %>
       </div>
 
       <div class="d-grid gap-2 d-md-flex justify-content-md-end">

--- a/app/views/images/show.html.erb
+++ b/app/views/images/show.html.erb
@@ -87,10 +87,7 @@
   <div class="card mb-4">
     <div class="card-header d-flex justify-content-between align-items-center">
       <span>OCR 結果</span>
-      <div>
-        <%= link_to "TXT", download_image_path(@image, format: "txt"), class: "btn btn-success btn-sm" %>
-        <%= link_to "MD", download_image_path(@image, format: "md"), class: "btn btn-outline-success btn-sm" %>
-      </div>
+      <%= link_to "ダウンロード", download_image_path(@image), class: "btn btn-success btn-sm" %>
     </div>
     <div class="card-body">
       <pre class="mb-0" style="white-space: pre-wrap; word-wrap: break-word;"><%= @image.ocr_result %></pre>


### PR DESCRIPTION
## Summary
以下の機能を追加・変更:

### セッション管理
- 認証方式ごと（ローカル/SAML/OIDC/パスキー）のセッションタイムアウト設定を追加

### OCR プロンプトパターン (#111)
- 管理者が複数のシステムプロンプトパターンを名前付きで登録可能
- 利用者がアップロード時にプルダウンでプロンプトを選択可能
- 使用したプロンプトを Image に記録
- デフォルトプロンプト設定を廃止し、プロンプトパターンのみで管理

### ダウンロードボタン改善 (#112)
- 画像詳細ページの TXT/MD ボタンを単一の「ダウンロード」ボタンに変更

### UI 調整
- 画像アップロード画面のレイアウト調整

## Test plan
- [ ] セッションタイムアウト設定が認証方式ごとに動作することを確認
- [ ] プロンプトパターンの CRUD が正常に動作することを確認
- [ ] 画像アップロード時にプロンプトパターンを選択できることを確認
- [ ] ダウンロードボタンで OCR 結果がダウンロードされることを確認

Closes #111
Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)