### PR TITLE
ポートバインドを 127.0.0.1 に限定

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   app:
     image: ghcr.io/aiuemon/kulip:0.1.32
     ports:
-      - "3000:80"
+      - "127.0.0.1:3000:80"
     env_file:
       - .env
     environment:


### PR DESCRIPTION
## 概要

- `docker-compose.yml` のポートバインドを `3000:80` → `127.0.0.1:3000:80` に変更

## 背景

現在の設定ではすべてのネットワークインタフェース（`0.0.0.0`）にバインドされており、リバースプロキシを経由せず外部から直接アクセスできてしまう可能性がある。`127.0.0.1` に限定することで、nginx 等のリバースプロキシ経由のみ受け付けるようにする。

## テスト計画

- [ ] ローカルで `docker compose up` して `localhost:3000` からアクセスできることを確認
- [ ] 外部 IP からの直接アクセスが拒否されることを確認

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)