### PR TITLE
net-imap を 0.6.4 に更新（CVE-2026-42245 等 5件の脆弱性修正）

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -220,7 +220,7 @@ GEM
     msgpack (1.8.0)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.6.3)
+    net-imap (0.6.4)
       date
       net-protocol
     net-pop (0.1.2)


### PR DESCRIPTION
## Summary

- `net-imap 0.6.3` に検出された 5件の CVE に対応するため `0.6.4` に更新
- `bundler-audit` による CI スキャンのブロックを解消する
- Dependabot PR (#130〜#134) が全てこの脆弱性で CI 失敗していたため、本 PR のマージで解消される

## 対象 CVE

| CVE | タイトル |
|-----|---------|
| CVE-2026-42245 | quadratic complexity when reading response literals |
| CVE-2026-42246 | STARTTLS stripping via invalid response timing |
| CVE-2026-42256 | denial of service via high iteration count for SCRAM-* |
| CVE-2026-42257 | command injection via "raw" arguments |
| CVE-2026-42258 | command injection via unvalidated Symbol inputs |

## Test plan

- [ ] CI (`scan_ruby` / `bundler-audit`) がパスすること
- [ ] テストが通ること

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)