### PR TITLE
ユーザ優先度と優先キュー処理を追加

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -69,6 +69,13 @@ module Admin
         anchor: "collapseTimezone",
         param_key: :timezone_settings,
         permitted: %i[timezone]
+      },
+      affil_priority: {
+        form_class: Forms::AffilPrioritySettingsForm,
+        message: "所属属性・優先度マッピングを更新しました。",
+        anchor: "collapseAffilPriority",
+        param_key: :affil_priority_settings,
+        permitted: { mappings: %i[affiliation priority] }
       }
     }.freeze
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,10 +1,10 @@
 module Admin
   class UsersController < BaseController
-    SORTABLE_COLUMNS = %w[id name email created_at].freeze
+    SORTABLE_COLUMNS = %w[id name email priority created_at].freeze
     DEFAULT_SORT = "created_at".freeze
     DEFAULT_DIR = "desc".freeze
 
-    before_action :set_user, only: %i[toggle_admin invalidate_sessions]
+    before_action :set_user, only: %i[toggle_admin invalidate_sessions update_priority]
 
     def index
       @sort = SORTABLE_COLUMNS.include?(params[:sort]) ? params[:sort] : DEFAULT_SORT
@@ -34,6 +34,19 @@ module Admin
 
       @user.invalidate_all_sessions!
       redirect_to admin_users_path, notice: "#{@user.email} のセッションを無効化しました。"
+    end
+
+    def update_priority
+      if @user == current_user
+        redirect_to admin_users_path, alert: "自分自身の優先度は変更できません。"
+        return
+      end
+
+      priority = params[:priority].to_i
+      @user.update!(priority: priority, priority_manually_set: true)
+      redirect_to admin_users_path, notice: "#{@user.email} の優先度を #{priority} に変更しました。"
+    rescue ActiveRecord::RecordInvalid => e
+      redirect_to admin_users_path, alert: "優先度の変更に失敗しました: #{e.message}"
     end
 
     private

--- a/app/javascript/controllers/affil_priority_controller.js
+++ b/app/javascript/controllers/affil_priority_controller.js
@@ -1,0 +1,39 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["mappings", "row"]
+
+  addRow() {
+    const index = this.rowTargets.length
+    const row = document.createElement("div")
+    row.className = "d-flex gap-2 mb-2 align-items-center"
+    row.setAttribute("data-affil-priority-target", "row")
+    row.innerHTML = `
+      <input type="text" name="affil_priority_settings[mappings][${index}][affiliation]"
+             class="form-control" style="max-width: 240px;" placeholder="例: faculty">
+      <select name="affil_priority_settings[mappings][${index}][priority]" class="form-select" style="width: auto">
+        <option value="1">優先度 1</option>
+        <option value="2">優先度 2</option>
+        <option value="3" selected>優先度 3</option>
+        <option value="4">優先度 4</option>
+        <option value="5">優先度 5</option>
+      </select>
+      <button type="button" class="btn btn-outline-danger btn-sm"
+              data-action="affil-priority#removeRow">削除</button>
+    `
+    this.mappingsTarget.appendChild(row)
+  }
+
+  removeRow(event) {
+    event.currentTarget.closest("[data-affil-priority-target='row']").remove()
+    this.#renumberRows()
+  }
+
+  #renumberRows() {
+    this.rowTargets.forEach((row, i) => {
+      row.querySelectorAll("input, select").forEach(el => {
+        el.name = el.name.replace(/\[mappings\]\[\d+\]/, `[mappings][${i}]`)
+      })
+    })
+  }
+}

--- a/app/jobs/ocr_process_job.rb
+++ b/app/jobs/ocr_process_job.rb
@@ -1,5 +1,5 @@
 class OcrProcessJob < ApplicationJob
-  queue_as :default
+  queue_as :priority_3
 
   retry_on OcrApiClient::TimeoutError, wait: 30.seconds, attempts: 3
   retry_on OcrApiClient::RequestError, wait: 1.minute, attempts: 2

--- a/app/models/forms/affil_priority_settings_form.rb
+++ b/app/models/forms/affil_priority_settings_form.rb
@@ -1,0 +1,57 @@
+module Forms
+  class AffilPrioritySettingsForm
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    attr_accessor :mappings
+
+    def initialize(attributes = {})
+      super
+      self.mappings ||= []
+      load_from_settings if attributes.empty?
+    end
+
+    validates_each :mappings do |record, attr, value|
+      Array(value).each do |m|
+        next if m[:affiliation].blank?
+
+        unless (1..5).include?(m[:priority].to_i)
+          record.errors.add(attr, "優先度は 1〜5 で入力してください")
+        end
+      end
+    end
+
+    def save
+      return false unless valid?
+
+      map = Array(mappings)
+        .reject { |m| m[:affiliation].blank? }
+        .to_h { |m| [ m[:affiliation].strip, m[:priority].to_i ] }
+      Setting.affiliation_priority_map = map
+      true
+    rescue => e
+      errors.add(:base, e.message)
+      false
+    end
+
+    def persisted?
+      true
+    end
+
+    def to_key
+      [ :affil_priority_settings ]
+    end
+
+    def model_name
+      ActiveModel::Name.new(self, nil, "AffilPrioritySettings")
+    end
+
+    private
+
+    def load_from_settings
+      self.mappings = Setting.affiliation_priority_map.map do |aff, pri|
+        { affiliation: aff, priority: pri.to_s }
+      end
+    end
+  end
+end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -89,6 +89,6 @@ class Image < ApplicationRecord
   def enqueue_ocr_processing
     return unless OcrApiClient.configured?
 
-    OcrProcessJob.perform_later(id)
+    OcrProcessJob.set(queue: "priority_#{user.priority}").perform_later(id)
   end
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -86,6 +86,9 @@ class Setting < RailsSettings::Base
   # === SAML SP 設定 ===
   field :saml_sp_entity_id, type: :string, default: ""
 
+  # === 優先度設定 ===
+  field :affiliation_priority_map, type: :hash, default: {}
+
   # === 互換性メソッド ===
   class << self
     # 認証設定
@@ -222,6 +225,17 @@ class Setting < RailsSettings::Base
     # SAML SP 設定
     def effective_saml_sp_entity_id(fallback = nil)
       saml_sp_entity_id.presence || fallback || "kuocr"
+    end
+
+    # 優先度設定
+    def priority_for_affiliations(affiliations)
+      return 3 if affiliations.blank?
+
+      map = affiliation_priority_map
+      return 3 if map.blank?
+
+      priorities = Array(affiliations).filter_map { |a| map[a.to_s]&.to_i }
+      priorities.select { |p| (1..5).include?(p) }.min || 3
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,11 +12,24 @@ class User < ApplicationRecord
 
   before_create :generate_webauthn_id
 
+  PRIORITIES = (1..5).freeze
+  validates :priority, inclusion: { in: PRIORITIES }
+
   def self.from_omniauth(auth)
     # メールアドレスで既存ユーザーを検索、なければ作成
     where(email: auth.info.email).first_or_create do |user|
       user.password = Devise.friendly_token[0, 20]
+      if auth.provider.to_s.start_with?("saml_")
+        user.priority = Setting.priority_for_affiliations(extract_saml_affiliations(auth))
+      end
     end
+  end
+
+  private_class_method def self.extract_saml_affiliations(auth)
+    raw = auth.extra&.raw_info
+    return [] unless raw
+
+    Array(raw["eduPersonAffiliation"]).map(&:to_s).reject(&:empty?)
   end
 
   def passkey_registered?

--- a/app/views/admin/settings/show.html.erb
+++ b/app/views/admin/settings/show.html.erb
@@ -532,4 +532,61 @@
       </div>
     </div>
   </div>
+
+  <div class="accordion-item">
+    <h2 class="accordion-header">
+      <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseAffilPriority" aria-expanded="false" aria-controls="collapseAffilPriority">
+        所属属性・優先度マッピング
+      </button>
+    </h2>
+    <div id="collapseAffilPriority" class="accordion-collapse collapse" data-bs-parent="#settingsAccordion">
+      <div class="accordion-body">
+        <div id="flash_affil_priority"></div>
+        <p class="text-muted">
+          SAML ログイン時に IdP から送られる <code>eduPersonAffiliation</code> 属性の値に応じて、ユーザの優先度（1〜5、小さいほど高優先）を自動設定します。<br>
+          複数の値がある場合は最高優先度（最小値）が採用されます。マッピングに存在しない値・属性が空の場合は優先度 3 が設定されます。
+        </p>
+
+        <%= form_with model: @affil_priority_form, url: update_affil_priority_admin_settings_path, method: :patch,
+                      data: { controller: "affil-priority" } do |f| %>
+          <% if @affil_priority_form.errors.any? %>
+            <div class="alert alert-danger">
+              <ul class="mb-0">
+                <% @affil_priority_form.errors.full_messages.each do |message| %>
+                  <li><%= message %></li>
+                <% end %>
+              </ul>
+            </div>
+          <% end %>
+
+          <div data-affil-priority-target="mappings">
+            <% Array(@affil_priority_form.mappings).each_with_index do |mapping, i| %>
+              <div class="d-flex gap-2 mb-2 align-items-center" data-affil-priority-target="row">
+                <input type="text" name="affil_priority_settings[mappings][<%= i %>][affiliation]"
+                       value="<%= mapping[:affiliation] %>"
+                       class="form-control" style="max-width: 240px;"
+                       placeholder="例: faculty">
+                <select name="affil_priority_settings[mappings][<%= i %>][priority]" class="form-select" style="width: auto">
+                  <% (1..5).each do |p| %>
+                    <option value="<%= p %>" <%= "selected" if mapping[:priority].to_i == p %>>優先度 <%= p %></option>
+                  <% end %>
+                </select>
+                <button type="button" class="btn btn-outline-danger btn-sm"
+                        data-action="affil-priority#removeRow">削除</button>
+              </div>
+            <% end %>
+          </div>
+
+          <div class="mb-3">
+            <button type="button" class="btn btn-outline-secondary btn-sm"
+                    data-action="affil-priority#addRow">+ 行を追加</button>
+          </div>
+
+          <div class="d-grid gap-2 d-md-flex justify-content-md-end">
+            <%= f.submit "保存", class: "btn btn-primary" %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
 </div>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -13,6 +13,7 @@
         <th>累計処理時間</th>
         <th>最終利用日時</th>
         <th>管理者</th>
+        <th><%= sort_link("優先度", :priority, @sort, @dir) %></th>
         <th>操作</th>
       </tr>
     </thead>
@@ -33,6 +34,12 @@
             <% end %>
           </td>
           <td>
+            <span class="badge bg-secondary"><%= user.priority %></span>
+            <% if user.priority_manually_set? %>
+              <span class="badge bg-warning text-dark ms-1">手動</span>
+            <% end %>
+          </td>
+          <td>
             <% if user != current_user %>
               <%= link_to(user.admin? ? "権限解除" : "権限付与",
                           toggle_admin_admin_user_path(user),
@@ -48,6 +55,16 @@
                             turbo_method: :patch,
                             turbo_confirm: "#{user.email} のセッションを無効化しますか？\nこのユーザは次回アクセス時に再ログインが必要になります。"
                           } %>
+              <form action="<%= update_priority_admin_user_path(user) %>" method="post" class="d-inline-flex align-items-center gap-1 ms-1">
+                <%= hidden_field_tag :_method, :patch %>
+                <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
+                <select name="priority" class="form-select form-select-sm" style="width: auto" aria-label="優先度">
+                  <% User::PRIORITIES.each do |p| %>
+                    <option value="<%= p %>" <%= "selected" if user.priority == p %>>優先度 <%= p %></option>
+                  <% end %>
+                </select>
+                <button type="submit" class="btn btn-sm btn-outline-secondary">変更</button>
+              </form>
             <% else %>
               <span class="badge bg-secondary">自分</span>
             <% end %>

--- a/config/queue.yml
+++ b/config/queue.yml
@@ -3,7 +3,8 @@ default: &default
     - polling_interval: 1
       batch_size: 500
   workers:
-    - queues: "*"
+    - queues: [priority_1, priority_2, priority_3, priority_4, priority_5, default]
+      ordered_queues: true
       threads: 3
       processes: <%= ENV.fetch("JOB_CONCURRENCY", 1) %>
       polling_interval: 0.1

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,12 +45,14 @@ Rails.application.routes.draw do
       patch :update_notification, on: :member
       patch :update_smtp, on: :member
       patch :update_timezone, on: :member
+      patch :update_affil_priority, on: :member
       post :send_test_email, on: :member
     end
     resources :users, only: %i[index] do
       member do
         patch :toggle_admin
         patch :invalidate_sessions
+        patch :update_priority
       end
     end
     resources :images, only: %i[index destroy]

--- a/db/migrate/20260621041338_add_priority_to_users.rb
+++ b/db/migrate/20260621041338_add_priority_to_users.rb
@@ -1,0 +1,7 @@
+class AddPriorityToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :priority, :integer, null: false, default: 3
+    add_column :users, :priority_manually_set, :boolean, null: false, default: false
+    add_check_constraint :users, "priority BETWEEN 1 AND 5", name: "chk_users_priority_range"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_17_092736) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_21_041338) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -131,6 +131,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_17_092736) do
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "name"
+    t.integer "priority", default: 3, null: false
+    t.boolean "priority_manually_set", default: false, null: false
     t.datetime "remember_created_at"
     t.datetime "reset_password_sent_at"
     t.string "reset_password_token"
@@ -140,6 +142,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_17_092736) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["webauthn_id"], name: "index_users_on_webauthn_id", unique: true
+    t.check_constraint "priority BETWEEN 1 AND 5", name: "chk_users_priority_range"
   end
 
   create_table "webauthn_credentials", force: :cascade do |t|

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -97,5 +97,45 @@ module Admin
       patch invalidate_sessions_admin_user_path(@admin)
       assert_redirected_to root_path
     end
+
+    test "update_priority changes user priority and sets priority_manually_set" do
+      sign_in @admin
+      assert_equal 3, @user.priority
+      assert_not @user.priority_manually_set?
+
+      patch update_priority_admin_user_path(@user), params: { priority: 1 }
+      assert_redirected_to admin_users_path
+      assert_match /優先度を 1 に変更しました/, flash[:notice]
+
+      @user.reload
+      assert_equal 1, @user.priority
+      assert @user.priority_manually_set?
+    end
+
+    test "update_priority rejects invalid priority" do
+      sign_in @admin
+      patch update_priority_admin_user_path(@user), params: { priority: 6 }
+      assert_redirected_to admin_users_path
+      assert_match /失敗しました/, flash[:alert]
+    end
+
+    test "update_priority cannot change own priority" do
+      sign_in @admin
+      original_priority = @admin.priority
+
+      patch update_priority_admin_user_path(@admin), params: { priority: 1 }
+      assert_redirected_to admin_users_path
+      assert_equal "自分自身の優先度は変更できません。", flash[:alert]
+
+      @admin.reload
+      assert_equal original_priority, @admin.priority
+    end
+
+    test "update_priority requires admin role" do
+      sign_in @user
+
+      patch update_priority_admin_user_path(@admin), params: { priority: 1 }
+      assert_redirected_to root_path
+    end
   end
 end

--- a/test/jobs/ocr_process_job_test.rb
+++ b/test/jobs/ocr_process_job_test.rb
@@ -28,8 +28,8 @@ class OcrProcessJobTest < ActiveJob::TestCase
     assert_equal "pending", image.status
   end
 
-  test "job is enqueued to default queue" do
-    assert_equal "default", OcrProcessJob.new.queue_name
+  test "job default queue is priority_3" do
+    assert_equal "priority_3", OcrProcessJob.new.queue_name
   end
 
   test "job class exists and inherits from ApplicationJob" do

--- a/test/models/forms/affil_priority_settings_form_test.rb
+++ b/test/models/forms/affil_priority_settings_form_test.rb
@@ -1,0 +1,61 @@
+require "test_helper"
+
+module Forms
+  class AffilPrioritySettingsFormTest < ActiveSupport::TestCase
+    setup do
+      Rails.cache.clear
+      Setting.affiliation_priority_map = {}
+    end
+
+    test "loads mappings from settings on initialize" do
+      Setting.affiliation_priority_map = { "faculty" => 1, "staff" => 2 }
+      form = AffilPrioritySettingsForm.new
+      assert_equal 2, form.mappings.length
+    end
+
+    test "save stores mappings to setting" do
+      form = AffilPrioritySettingsForm.new(
+        mappings: [
+          { affiliation: "faculty", priority: "1" },
+          { affiliation: "staff", priority: "2" }
+        ]
+      )
+      assert form.save
+      assert_equal({ "faculty" => 1, "staff" => 2 }, Setting.affiliation_priority_map)
+    end
+
+    test "save skips blank affiliation rows" do
+      form = AffilPrioritySettingsForm.new(
+        mappings: [
+          { affiliation: "", priority: "1" },
+          { affiliation: "faculty", priority: "2" }
+        ]
+      )
+      assert form.save
+      assert_equal({ "faculty" => 2 }, Setting.affiliation_priority_map)
+    end
+
+    test "save strips whitespace from affiliation" do
+      form = AffilPrioritySettingsForm.new(
+        mappings: [{ affiliation: "  faculty  ", priority: "1" }]
+      )
+      assert form.save
+      assert Setting.affiliation_priority_map.key?("faculty")
+    end
+
+    test "invalid when priority out of range" do
+      form = AffilPrioritySettingsForm.new(
+        mappings: [{ affiliation: "faculty", priority: "6" }]
+      )
+      assert_not form.valid?
+      assert form.errors[:mappings].present?
+    end
+
+    test "save with empty mappings clears the setting" do
+      Setting.affiliation_priority_map = { "faculty" => 1 }
+      form = AffilPrioritySettingsForm.new(mappings: [])
+      assert form.save
+      assert_equal({}, Setting.affiliation_priority_map)
+    end
+  end
+end

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -1,6 +1,7 @@
 require "test_helper"
 
 class ImageTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
   test "valid statuses" do
     assert_equal %w[pending queued processing completed failed], Image::STATUSES
   end
@@ -245,5 +246,19 @@ class ImageTest < ActiveSupport::TestCase
     image.ocr_prompt_text = nil
     OcrPromptPattern.delete_all
     assert_nil image.effective_ocr_prompt
+  end
+
+  test "enqueue_ocr_processing uses queue matching user priority" do
+    Setting.ocr_endpoint = "http://example.com/api"
+    Setting.ocr_model = "llava:latest"
+
+    user = users(:user)
+    user.update!(priority: 2)
+    image = images(:pending_image)
+    image.update_column(:user_id, user.id)
+
+    assert_enqueued_with(job: OcrProcessJob, queue: "priority_2") do
+      image.send(:enqueue_ocr_processing)
+    end
   end
 end

--- a/test/models/setting_test.rb
+++ b/test/models/setting_test.rb
@@ -86,4 +86,36 @@ class SettingTest < ActiveSupport::TestCase
     assert_equal 24.hours, Setting.timeout_for_auth_method("unknown")
     assert_equal 24.hours, Setting.timeout_for_auth_method(nil)
   end
+
+  test "priority_for_affiliations returns 3 when affiliations blank" do
+    Setting.affiliation_priority_map = { "faculty" => 1 }
+    assert_equal 3, Setting.priority_for_affiliations([])
+    assert_equal 3, Setting.priority_for_affiliations(nil)
+  end
+
+  test "priority_for_affiliations returns 3 when map is empty" do
+    Setting.affiliation_priority_map = {}
+    assert_equal 3, Setting.priority_for_affiliations(["faculty"])
+  end
+
+  test "priority_for_affiliations returns mapped priority" do
+    Setting.affiliation_priority_map = { "faculty" => 1, "staff" => 2 }
+    assert_equal 1, Setting.priority_for_affiliations(["faculty"])
+    assert_equal 2, Setting.priority_for_affiliations(["staff"])
+  end
+
+  test "priority_for_affiliations returns minimum priority for multiple affiliations" do
+    Setting.affiliation_priority_map = { "faculty" => 1, "member" => 3 }
+    assert_equal 1, Setting.priority_for_affiliations(["member", "faculty"])
+  end
+
+  test "priority_for_affiliations returns 3 when no affiliation matches map" do
+    Setting.affiliation_priority_map = { "faculty" => 1 }
+    assert_equal 3, Setting.priority_for_affiliations(["unknown"])
+  end
+
+  test "priority_for_affiliations ignores out-of-range values in map" do
+    Setting.affiliation_priority_map = { "bad" => 0, "faculty" => 2 }
+    assert_equal 2, Setting.priority_for_affiliations(["bad", "faculty"])
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -49,6 +49,105 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
+  test "priority defaults to 3" do
+    user = users(:user)
+    assert_equal 3, user.priority
+  end
+
+  test "priority_manually_set defaults to false" do
+    user = users(:user)
+    assert_not user.priority_manually_set?
+  end
+
+  test "priority must be between 1 and 5" do
+    user = users(:user)
+    user.priority = 0
+    assert_not user.valid?
+
+    user.priority = 6
+    assert_not user.valid?
+
+    (1..5).each do |p|
+      user.priority = p
+      assert user.valid?, "priority #{p} should be valid"
+    end
+  end
+
+  test "from_omniauth sets priority from SAML affiliations" do
+    Setting.affiliation_priority_map = { "faculty" => 1, "staff" => 2 }
+    auth = OpenStruct.new(
+      provider: "saml_test",
+      info: OpenStruct.new(email: "saml_new@example.com"),
+      extra: OpenStruct.new(raw_info: { "eduPersonAffiliation" => ["faculty"] })
+    )
+
+    user = User.from_omniauth(auth)
+    assert_equal 1, user.priority
+  end
+
+  test "from_omniauth picks highest priority (minimum value) when multiple affiliations match" do
+    Setting.affiliation_priority_map = { "faculty" => 1, "member" => 3 }
+    auth = OpenStruct.new(
+      provider: "saml_test",
+      info: OpenStruct.new(email: "saml_multi@example.com"),
+      extra: OpenStruct.new(raw_info: { "eduPersonAffiliation" => ["member", "faculty"] })
+    )
+
+    user = User.from_omniauth(auth)
+    assert_equal 1, user.priority
+  end
+
+  test "from_omniauth defaults to priority 3 when affiliation not in map" do
+    Setting.affiliation_priority_map = { "faculty" => 1 }
+    auth = OpenStruct.new(
+      provider: "saml_test",
+      info: OpenStruct.new(email: "saml_unknown@example.com"),
+      extra: OpenStruct.new(raw_info: { "eduPersonAffiliation" => ["unknown_role"] })
+    )
+
+    user = User.from_omniauth(auth)
+    assert_equal 3, user.priority
+  end
+
+  test "from_omniauth defaults to priority 3 when eduPersonAffiliation is blank" do
+    Setting.affiliation_priority_map = { "faculty" => 1 }
+    auth = OpenStruct.new(
+      provider: "saml_test",
+      info: OpenStruct.new(email: "saml_noaffil@example.com"),
+      extra: OpenStruct.new(raw_info: {})
+    )
+
+    user = User.from_omniauth(auth)
+    assert_equal 3, user.priority
+  end
+
+  test "from_omniauth does not set priority from OIDC (defaults to 3)" do
+    Setting.affiliation_priority_map = { "faculty" => 1 }
+    auth = OpenStruct.new(
+      provider: "oidc_test",
+      info: OpenStruct.new(email: "oidc_new@example.com"),
+      extra: OpenStruct.new(raw_info: { "eduPersonAffiliation" => ["faculty"] })
+    )
+
+    user = User.from_omniauth(auth)
+    assert_equal 3, user.priority
+  end
+
+  test "from_omniauth does not update priority for existing users" do
+    existing_user = users(:user)
+    existing_user.update!(priority: 2)
+    Setting.affiliation_priority_map = { "faculty" => 1 }
+    auth = OpenStruct.new(
+      provider: "saml_test",
+      info: OpenStruct.new(email: existing_user.email),
+      extra: OpenStruct.new(raw_info: { "eduPersonAffiliation" => ["faculty"] })
+    )
+
+    User.from_omniauth(auth)
+    existing_user.reload
+    assert_equal 2, existing_user.priority
+  end
+
   test "storage_usage_bytes returns total size of uploaded images" do
     user = users(:user)
     assert_respond_to user, :storage_usage_bytes


### PR DESCRIPTION
## 概要

ユーザを 5 段階の優先度（1〜5、数字が小さいほど高優先）に分類し、優先度に応じて文字起こし処理の順序を制御する。

## 変更内容

### DB
- `users.priority`（integer, default: 3, NOT NULL, CHECK 1-5）
- `users.priority_manually_set`（boolean, default: false, NOT NULL）

### ユーザ優先度の自動設定
- SAML 初回ログイン時に `eduPersonAffiliation` 属性を参照して優先度を自動設定
- 複数 affiliation がある場合は最高優先度（最小値）を採用
- マッピング未定義・属性が空の場合はデフォルト 3
- OIDC ログインはデフォルト 3（自動設定なし）

### 優先キュー
- `priority_1`〜`priority_5` の 5 キューを追加
- Solid Queue の `ordered_queues: true` で厳格な優先制御（上位キューが空になるまで下位キューを処理しない）
- OCR ジョブはユーザの優先度に対応するキューへ振り分け（`Image#enqueue_ocr_processing`）

### 管理者機能
- 設定画面: affiliation 文字列 → 優先度のマッピングを設定（Stimulus で行の動的追加/削除）
- ユーザ一覧: 優先度カラム追加（手動変更済みは「手動」バッジ表示）、インラインで優先度変更可能

## テスト

- 348 テスト通過（既存の HEIC コーデック未インストールによる 1 エラーは変更前から存在する既知の問題）
- 新規追加: User, Setting, Image, AffilPrioritySettingsForm, Admin::UsersController の各テスト

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)