### PR TITLE
CI 失敗の修正: ruby-vips 起動エラーと bundler-audit 脆弱性

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ gem "thruster", require: false
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 gem "image_processing", "~> 2.0"
-gem "ruby-vips"
+gem "ruby-vips", require: false
 
 # ZIP file generation
 gem "rubyzip"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,13 +130,13 @@ GEM
     erubi (1.13.1)
     et-orbi (1.4.0)
       tzinfo
-    faraday (2.14.1)
+    faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
     faraday-follow_redirects (0.5.0)
       faraday (>= 1, < 3)
-    faraday-net_http (3.4.2)
+    faraday-net_http (3.4.4)
       net-http (~> 0.5)
     ffi (1.17.4-aarch64-linux-gnu)
     ffi (1.17.4-aarch64-linux-musl)
@@ -180,7 +180,7 @@ GEM
     json-schema (6.2.0)
       addressable (~> 2.8)
       bigdecimal (>= 3.1, < 5)
-    jwt (3.1.2)
+    jwt (3.2.0)
       base64
     kamal (2.11.0)
       activesupport (>= 7.0)
@@ -216,7 +216,7 @@ GEM
     msgpack (1.8.3)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.6.4)
+    net-imap (0.6.4.1)
       date
       net-protocol
     net-pop (0.1.2)

--- a/app/services/heic_processing_service.rb
+++ b/app/services/heic_processing_service.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "tmpdir"
-require "vips"
 
 # HEIC/HEIF 画像を PNG に変換するサービス
 # libvips + libheif を使用

--- a/app/services/heic_processing_service.rb
+++ b/app/services/heic_processing_service.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "tmpdir"
+require "vips"
 
 # HEIC/HEIF 画像を PNG に変換するサービス
 # libvips + libheif を使用

--- a/db/cable_schema.rb
+++ b/db/cable_schema.rb
@@ -4,8 +4,8 @@ ActiveRecord::Schema[7.1].define(version: 1) do
     t.binary "payload", limit: 536870912, null: false
     t.datetime "created_at", null: false
     t.integer "channel_hash", limit: 8, null: false
-    t.index ["channel"], name: "index_solid_cable_messages_on_channel"
-    t.index ["channel_hash"], name: "index_solid_cable_messages_on_channel_hash"
-    t.index ["created_at"], name: "index_solid_cable_messages_on_created_at"
+    t.index [ "channel" ], name: "index_solid_cable_messages_on_channel"
+    t.index [ "channel_hash" ], name: "index_solid_cable_messages_on_channel_hash"
+    t.index [ "created_at" ], name: "index_solid_cable_messages_on_created_at"
   end
 end

--- a/db/cache_schema.rb
+++ b/db/cache_schema.rb
@@ -5,8 +5,8 @@ ActiveRecord::Schema[7.2].define(version: 1) do
     t.datetime "created_at", null: false
     t.integer "key_hash", limit: 8, null: false
     t.integer "byte_size", limit: 4, null: false
-    t.index ["byte_size"], name: "index_solid_cache_entries_on_byte_size"
-    t.index ["key_hash", "byte_size"], name: "index_solid_cache_entries_on_key_hash_and_byte_size"
-    t.index ["key_hash"], name: "index_solid_cache_entries_on_key_hash", unique: true
+    t.index [ "byte_size" ], name: "index_solid_cache_entries_on_byte_size"
+    t.index [ "key_hash", "byte_size" ], name: "index_solid_cache_entries_on_key_hash_and_byte_size"
+    t.index [ "key_hash" ], name: "index_solid_cache_entries_on_key_hash", unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -17,8 +17,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_21_041338) do
     t.string "name", null: false
     t.bigint "record_id", null: false
     t.string "record_type", null: false
-    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
-    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+    t.index [ "blob_id" ], name: "index_active_storage_attachments_on_blob_id"
+    t.index [ "record_type", "record_id", "name", "blob_id" ], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
   create_table "active_storage_blobs", force: :cascade do |t|
@@ -30,13 +30,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_21_041338) do
     t.string "key", null: false
     t.text "metadata"
     t.string "service_name", null: false
-    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+    t.index [ "key" ], name: "index_active_storage_blobs_on_key", unique: true
   end
 
   create_table "active_storage_variant_records", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
-    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+    t.index [ "blob_id", "variation_digest" ], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
   create_table "auth_settings", force: :cascade do |t|
@@ -56,9 +56,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_21_041338) do
     t.boolean "show_on_login", default: true, null: false
     t.string "slug", null: false
     t.datetime "updated_at", null: false
-    t.index ["enabled"], name: "index_identity_providers_on_enabled"
-    t.index ["provider_type"], name: "index_identity_providers_on_provider_type"
-    t.index ["slug"], name: "index_identity_providers_on_slug", unique: true
+    t.index [ "enabled" ], name: "index_identity_providers_on_enabled"
+    t.index [ "provider_type" ], name: "index_identity_providers_on_provider_type"
+    t.index [ "slug" ], name: "index_identity_providers_on_slug", unique: true
   end
 
   create_table "image_groups", force: :cascade do |t|
@@ -66,7 +66,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_21_041338) do
     t.string "memo"
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false
-    t.index ["user_id"], name: "index_image_groups_on_user_id"
+    t.index [ "user_id" ], name: "index_image_groups_on_user_id"
   end
 
   create_table "images", force: :cascade do |t|
@@ -82,11 +82,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_21_041338) do
     t.string "status", default: "pending", null: false
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false
-    t.index ["image_group_id"], name: "index_images_on_image_group_id"
-    t.index ["ocr_prompt_pattern_id"], name: "index_images_on_ocr_prompt_pattern_id"
-    t.index ["purged_at"], name: "index_images_on_purged_at"
-    t.index ["status"], name: "index_images_on_status"
-    t.index ["user_id"], name: "index_images_on_user_id"
+    t.index [ "image_group_id" ], name: "index_images_on_image_group_id"
+    t.index [ "ocr_prompt_pattern_id" ], name: "index_images_on_ocr_prompt_pattern_id"
+    t.index [ "purged_at" ], name: "index_images_on_purged_at"
+    t.index [ "status" ], name: "index_images_on_status"
+    t.index [ "user_id" ], name: "index_images_on_user_id"
   end
 
   create_table "ocr_prompt_patterns", force: :cascade do |t|
@@ -96,8 +96,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_21_041338) do
     t.integer "position", default: 0
     t.text "prompt", null: false
     t.datetime "updated_at", null: false
-    t.index ["is_default"], name: "index_ocr_prompt_patterns_on_is_default"
-    t.index ["position"], name: "index_ocr_prompt_patterns_on_position"
+    t.index [ "is_default" ], name: "index_ocr_prompt_patterns_on_is_default"
+    t.index [ "position" ], name: "index_ocr_prompt_patterns_on_position"
   end
 
   create_table "ocr_settings", force: :cascade do |t|
@@ -122,7 +122,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_21_041338) do
     t.datetime "updated_at", null: false
     t.text "value"
     t.string "var", null: false
-    t.index ["var"], name: "index_settings_on_var", unique: true
+    t.index [ "var" ], name: "index_settings_on_var", unique: true
   end
 
   create_table "users", force: :cascade do |t|
@@ -139,9 +139,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_21_041338) do
     t.datetime "sessions_invalidated_at"
     t.datetime "updated_at", null: false
     t.string "webauthn_id"
-    t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
-    t.index ["webauthn_id"], name: "index_users_on_webauthn_id", unique: true
+    t.index [ "email" ], name: "index_users_on_email", unique: true
+    t.index [ "reset_password_token" ], name: "index_users_on_reset_password_token", unique: true
+    t.index [ "webauthn_id" ], name: "index_users_on_webauthn_id", unique: true
     t.check_constraint "priority BETWEEN 1 AND 5", name: "chk_users_priority_range"
   end
 
@@ -155,8 +155,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_21_041338) do
     t.bigint "sign_count", default: 0, null: false
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false
-    t.index ["external_id"], name: "index_webauthn_credentials_on_external_id", unique: true
-    t.index ["user_id"], name: "index_webauthn_credentials_on_user_id"
+    t.index [ "external_id" ], name: "index_webauthn_credentials_on_external_id", unique: true
+    t.index [ "user_id" ], name: "index_webauthn_credentials_on_user_id"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/test/models/forms/affil_priority_settings_form_test.rb
+++ b/test/models/forms/affil_priority_settings_form_test.rb
@@ -37,7 +37,7 @@ module Forms
 
     test "save strips whitespace from affiliation" do
       form = AffilPrioritySettingsForm.new(
-        mappings: [{ affiliation: "  faculty  ", priority: "1" }]
+        mappings: [ { affiliation: "  faculty  ", priority: "1" } ]
       )
       assert form.save
       assert Setting.affiliation_priority_map.key?("faculty")
@@ -45,7 +45,7 @@ module Forms
 
     test "invalid when priority out of range" do
       form = AffilPrioritySettingsForm.new(
-        mappings: [{ affiliation: "faculty", priority: "6" }]
+        mappings: [ { affiliation: "faculty", priority: "6" } ]
       )
       assert_not form.valid?
       assert form.errors[:mappings].present?

--- a/test/models/setting_test.rb
+++ b/test/models/setting_test.rb
@@ -95,27 +95,27 @@ class SettingTest < ActiveSupport::TestCase
 
   test "priority_for_affiliations returns 3 when map is empty" do
     Setting.affiliation_priority_map = {}
-    assert_equal 3, Setting.priority_for_affiliations(["faculty"])
+    assert_equal 3, Setting.priority_for_affiliations([ "faculty" ])
   end
 
   test "priority_for_affiliations returns mapped priority" do
     Setting.affiliation_priority_map = { "faculty" => 1, "staff" => 2 }
-    assert_equal 1, Setting.priority_for_affiliations(["faculty"])
-    assert_equal 2, Setting.priority_for_affiliations(["staff"])
+    assert_equal 1, Setting.priority_for_affiliations([ "faculty" ])
+    assert_equal 2, Setting.priority_for_affiliations([ "staff" ])
   end
 
   test "priority_for_affiliations returns minimum priority for multiple affiliations" do
     Setting.affiliation_priority_map = { "faculty" => 1, "member" => 3 }
-    assert_equal 1, Setting.priority_for_affiliations(["member", "faculty"])
+    assert_equal 1, Setting.priority_for_affiliations([ "member", "faculty" ])
   end
 
   test "priority_for_affiliations returns 3 when no affiliation matches map" do
     Setting.affiliation_priority_map = { "faculty" => 1 }
-    assert_equal 3, Setting.priority_for_affiliations(["unknown"])
+    assert_equal 3, Setting.priority_for_affiliations([ "unknown" ])
   end
 
   test "priority_for_affiliations ignores out-of-range values in map" do
     Setting.affiliation_priority_map = { "bad" => 0, "faculty" => 2 }
-    assert_equal 2, Setting.priority_for_affiliations(["bad", "faculty"])
+    assert_equal 2, Setting.priority_for_affiliations([ "bad", "faculty" ])
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -78,7 +78,7 @@ class UserTest < ActiveSupport::TestCase
     auth = OpenStruct.new(
       provider: "saml_test",
       info: OpenStruct.new(email: "saml_new@example.com"),
-      extra: OpenStruct.new(raw_info: { "eduPersonAffiliation" => ["faculty"] })
+      extra: OpenStruct.new(raw_info: { "eduPersonAffiliation" => [ "faculty" ] })
     )
 
     user = User.from_omniauth(auth)
@@ -90,7 +90,7 @@ class UserTest < ActiveSupport::TestCase
     auth = OpenStruct.new(
       provider: "saml_test",
       info: OpenStruct.new(email: "saml_multi@example.com"),
-      extra: OpenStruct.new(raw_info: { "eduPersonAffiliation" => ["member", "faculty"] })
+      extra: OpenStruct.new(raw_info: { "eduPersonAffiliation" => [ "member", "faculty" ] })
     )
 
     user = User.from_omniauth(auth)
@@ -102,7 +102,7 @@ class UserTest < ActiveSupport::TestCase
     auth = OpenStruct.new(
       provider: "saml_test",
       info: OpenStruct.new(email: "saml_unknown@example.com"),
-      extra: OpenStruct.new(raw_info: { "eduPersonAffiliation" => ["unknown_role"] })
+      extra: OpenStruct.new(raw_info: { "eduPersonAffiliation" => [ "unknown_role" ] })
     )
 
     user = User.from_omniauth(auth)
@@ -126,7 +126,7 @@ class UserTest < ActiveSupport::TestCase
     auth = OpenStruct.new(
       provider: "oidc_test",
       info: OpenStruct.new(email: "oidc_new@example.com"),
-      extra: OpenStruct.new(raw_info: { "eduPersonAffiliation" => ["faculty"] })
+      extra: OpenStruct.new(raw_info: { "eduPersonAffiliation" => [ "faculty" ] })
     )
 
     user = User.from_omniauth(auth)
@@ -140,7 +140,7 @@ class UserTest < ActiveSupport::TestCase
     auth = OpenStruct.new(
       provider: "saml_test",
       info: OpenStruct.new(email: existing_user.email),
-      extra: OpenStruct.new(raw_info: { "eduPersonAffiliation" => ["faculty"] })
+      extra: OpenStruct.new(raw_info: { "eduPersonAffiliation" => [ "faculty" ] })
     )
 
     User.from_omniauth(auth)


### PR DESCRIPTION
## 概要

main の CI が 2 つの原因で失敗していたので修正する。

## 修正内容

### 1. ruby-vips 起動エラー（scan_js / test ジョブ失敗）

PR #153 で `ruby-vips` を Gemfile に明示追加した際に `require: false` を付けなかったため、Rails 起動時に libvips の native ライブラリのロードが試みられ、CI 環境（libvips 未インストール）でクラッシュしていた。

- `Gemfile`: `gem "ruby-vips", require: false` に変更
- `HeicProcessingService`: `require "vips"` を明示追加（実際に使う箇所で読み込む）

### 2. bundler-audit 脆弱性（scan_ruby ジョブ失敗）

- `faraday` 2.14.1 → **2.14.3** (CVE-2026-33637, Medium: protocol-relative URI bypass)
- `jwt` 3.1.2 → **3.2.0** (CVE-2026-45363, **High**: Empty-key HMAC bypass)
- `net-imap` 0.6.4 → **0.6.4.1** (CVE-2026-47240/47241/47242: Command Injection / DoS)

## テスト

- 348 テスト通過
- `bin/bundler-audit` → No vulnerabilities found

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)