### PR TITLE
OCRプロバイダー設定が保存されない問題を修正

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -26,7 +26,7 @@ module Admin
         message: "OCR設定を更新しました。",
         anchor: "collapseOcr",
         param_key: :ocr_settings,
-        permitted: %i[endpoint api_key timeout model prompt options skip_ssl_verify]
+        permitted: %i[provider endpoint api_key timeout model prompt options skip_ssl_verify]
       },
       quota: {
         form_class: Forms::QuotaSettingsForm,

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -64,14 +64,18 @@ module Admin
     end
 
     # OCR settings tests
-    test "update_ocr changes endpoint" do
+    test "update_ocr changes provider and endpoint" do
       sign_in @admin
 
       patch update_ocr_admin_settings_path, params: {
-        ocr_settings: { endpoint: "http://new.example.com/api" }
+        ocr_settings: {
+          provider: "openai_compatible",
+          endpoint: "http://new.example.com/api"
+        }
       }
 
       assert_redirected_to admin_settings_path(anchor: "collapseOcr")
+      assert_equal "openai_compatible", Setting.ocr_provider
       assert_equal "http://new.example.com/api", Setting.ocr_endpoint
     end
 


### PR DESCRIPTION
## 概要

管理画面でOCRプロバイダーをOpenAI互換APIへ変更して保存しても、Ollamaへ戻ってしまう問題を修正します。

## 原因

OCR設定フォームは `provider` を保存する実装になっていましたが、`Admin::SettingsController` のStrong Parametersに `provider` が含まれていませんでした。そのため、保存処理へ値が渡らず、既定のOllamaが使用されていました。

## 変更内容

- OCR設定の許可パラメーターに `provider` を追加
- プロバイダーとエンドポイントが同時に保存されることをコントローラーテストで確認
