### PR TITLE
MailerへのSMTP設定適用タイミングを修正

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -3,7 +3,7 @@ class ApplicationMailer < ActionMailer::Base
 
   default from: -> { Setting.smtp_from_address.presence || "noreply@example.com" }
 
-  before_action :configure_smtp_settings
+  after_action :configure_smtp_settings
 
   private
 

--- a/app/mailers/test_mailer.rb
+++ b/app/mailers/test_mailer.rb
@@ -1,5 +1,5 @@
 class TestMailer < ApplicationMailer
-  skip_before_action :configure_smtp_settings
+  skip_after_action :configure_smtp_settings
 
   def test_email(to:, smtp_settings: {})
     @sent_at = Time.current

--- a/test/mailers/ocr_completion_mailer_test.rb
+++ b/test/mailers/ocr_completion_mailer_test.rb
@@ -41,6 +41,25 @@ class OcrCompletionMailerTest < ActionMailer::TestCase
     assert_equal Setting::DEFAULT_NOTIFICATION_SUBJECT, email.subject
   end
 
+  test "completion_notification applies configured smtp settings" do
+    Setting.smtp_enabled = true
+    Setting.smtp_address = "smtp.example.com"
+    Setting.smtp_port = 587
+    Setting.smtp_authentication = "plain"
+    Setting.smtp_user_name = "user@example.com"
+    Setting.smtp_password = "secret"
+    Setting.smtp_enable_starttls = true
+
+    email = OcrCompletionMailer.completion_notification(@image)
+
+    assert_equal "smtp.example.com", email.delivery_method.settings[:address]
+    assert_equal 587, email.delivery_method.settings[:port]
+    assert_equal :plain, email.delivery_method.settings[:authentication]
+    assert_equal "user@example.com", email.delivery_method.settings[:user_name]
+    assert_equal "secret", email.delivery_method.settings[:password]
+    assert_equal true, email.delivery_method.settings[:enable_starttls_auto]
+  end
+
   test "completion_notification does not send when user has no email" do
     @image.user.email = nil
 


### PR DESCRIPTION
## 概要

管理画面で保存したSMTP設定を、メールメッセージ生成後のDelivery Methodへ適用するよう修正します。

## 背景

従来は `ApplicationMailer` の `before_action` でSMTP設定を反映していました。この時点ではMailerアクション内の `mail(...)` がまだ実行されていないため、生成されたメールのDelivery Methodへ設定を確実に反映できませんでした。

## 変更内容

- SMTP設定の適用コールバックを `before_action` から `after_action` へ変更
- テストメールでは画面入力されたSMTP設定を優先するため、自動設定を `skip_after_action` でスキップ
- 通知メールのDelivery Methodへ、保存済みのSMTPホスト、ポート、認証情報、STARTTLS設定が反映されることをテスト

## テスト

```console
bin/rails test test/mailers/ocr_completion_mailer_test.rb test/controllers/admin/settings_controller_test.rb
```

分割前の統合差分では、上記を含む関連テストで `70 runs, 200 assertions, 0 failures, 0 errors, 0 skips` を確認済みです。

SMTPサーバーへの実配送は環境依存のため、自動テストの対象外です。
