### PR TITLE
PDF OCRの変換DPIを管理画面から設定可能にする

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -47,7 +47,7 @@ module Admin
         message: "PDF設定を更新しました。",
         anchor: "collapseUserFiles",
         param_key: :pdf_settings,
-        permitted: %i[max_pages]
+        permitted: %i[max_pages dpi]
       },
       notification: {
         form_class: Forms::NotificationSettingsForm,

--- a/app/models/forms/pdf_settings_form.rb
+++ b/app/models/forms/pdf_settings_form.rb
@@ -5,10 +5,22 @@ module Forms
     include ActiveModel::Model
     include ActiveModel::Attributes
 
+    DPI_OPTIONS = [
+      [ "高速 (96dpi)", 96 ],
+      [ "標準 (120dpi)", 120 ],
+      [ "高精度 (150dpi)", 150 ],
+      [ "最高精度 (200dpi)", 200 ]
+    ].freeze
+
     attribute :max_pages, :integer
+    attribute :dpi, :integer
 
     validates :max_pages,
       numericality: { greater_than: 0, less_than_or_equal_to: 100, message: "は1〜100の範囲で指定してください" },
+      allow_blank: true
+
+    validates :dpi,
+      inclusion: { in: Setting::PDF_DPI_OPTIONS, message: "は96、120、150、200のいずれかを指定してください" },
       allow_blank: true
 
     def initialize(attributes = {})
@@ -20,6 +32,7 @@ module Forms
       return false unless valid?
 
       Setting.pdf_max_pages = max_pages.presence || Setting::DEFAULT_PDF_MAX_PAGES
+      Setting.pdf_dpi = dpi.presence || Setting::DEFAULT_PDF_DPI
       true
     rescue => e
       errors.add(:base, e.message)
@@ -41,7 +54,8 @@ module Forms
     private
 
     def load_from_settings
-      self.max_pages = Setting.pdf_max_pages
+      self.max_pages = Setting.effective_pdf_max_pages
+      self.dpi = Setting.effective_pdf_dpi
     end
   end
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -15,6 +15,8 @@ class Setting < RailsSettings::Base
   DEFAULT_MAX_STORAGE_MB = 1024
   DEFAULT_AUTO_PURGE_DAYS = 7
   DEFAULT_PDF_MAX_PAGES = 20
+  DEFAULT_PDF_DPI = 120
+  PDF_DPI_OPTIONS = [ 96, 120, 150, 200 ].freeze
 
   DEFAULT_TIMEZONE = "Asia/Tokyo".freeze
 
@@ -63,6 +65,7 @@ class Setting < RailsSettings::Base
 
   # === PDF設定 ===
   field :pdf_max_pages, type: :integer, default: 20
+  field :pdf_dpi, type: :integer, default: DEFAULT_PDF_DPI
 
   # === メール通知設定 ===
   field :notification_email_enabled, type: :boolean, default: false
@@ -170,6 +173,11 @@ class Setting < RailsSettings::Base
     def effective_pdf_max_pages
       pages = pdf_max_pages
       pages.present? && pages > 0 ? pages : DEFAULT_PDF_MAX_PAGES
+    end
+
+    def effective_pdf_dpi
+      dpi = pdf_dpi.to_i
+      PDF_DPI_OPTIONS.include?(dpi) ? dpi : DEFAULT_PDF_DPI
     end
 
     # メール通知設定

--- a/app/services/pdf_processing_service.rb
+++ b/app/services/pdf_processing_service.rb
@@ -4,13 +4,12 @@ require "open3"
 require "tmpdir"
 
 # PDF ファイルを画像に変換するサービス
-# poppler-utils の pdftoppm を使用して各ページを PNG に変換する
+# poppler-utils の pdftoppm を使用して各ページを JPEG に変換する
 class PdfProcessingService
   class Error < StandardError; end
   class PageLimitExceededError < Error; end
   class ConversionError < Error; end
 
-  DPI = 200
   IMAGE_FORMAT = "jpeg"  # pdftoppm のオプション名
   FILE_EXTENSION = "jpg" # 出力ファイルの拡張子
 
@@ -18,6 +17,7 @@ class PdfProcessingService
     @pdf_data = pdf_data
     @filename = filename
     @max_pages = Setting.effective_pdf_max_pages
+    @dpi = Setting.effective_pdf_dpi
   end
 
   # PDF のページ数を取得
@@ -73,11 +73,11 @@ class PdfProcessingService
   end
 
   def convert_pdf_to_images(pdf_path, output_prefix)
-    # pdftoppm -jpeg -r 200 input.pdf output_prefix
+    # pdftoppm -jpeg -r <dpi> input.pdf output_prefix
     _stdout, stderr, status = Open3.capture3(
       "pdftoppm",
       "-#{IMAGE_FORMAT}",
-      "-r", DPI.to_s,
+      "-r", @dpi.to_s,
       pdf_path,
       output_prefix
     )

--- a/app/views/admin/settings/show.html.erb
+++ b/app/views/admin/settings/show.html.erb
@@ -431,6 +431,15 @@
             </div>
           </div>
 
+          <div class="mb-3">
+            <%= f.label :dpi, "PDF 変換品質", class: "form-label" %>
+            <%= f.select :dpi, Forms::PdfSettingsForm::DPI_OPTIONS, {}, class: "form-select", style: "max-width: 280px;" %>
+            <div class="form-text">
+              OCR 前に PDF を画像へ変換する解像度を設定します。低いほど高速ですが、小さい文字の精度が落ちる場合があります。<br>
+              現在の設定: <strong><%= Setting.effective_pdf_dpi %> dpi</strong>
+            </div>
+          </div>
+
           <div class="d-grid gap-2 d-md-flex justify-content-md-end">
             <%= f.submit "保存", class: "btn btn-primary" %>
           </div>

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -303,27 +303,30 @@ module Admin
     end
 
     # PDF settings tests
-    test "update_pdf changes max pages" do
+    test "update_pdf changes max pages and dpi" do
       sign_in @admin
 
       patch update_pdf_admin_settings_path, params: {
-        pdf_settings: { max_pages: 50 }
+        pdf_settings: { max_pages: 50, dpi: 150 }
       }
 
       assert_redirected_to admin_settings_path(anchor: "collapseUserFiles")
       assert_equal 50, Setting.pdf_max_pages
+      assert_equal 150, Setting.pdf_dpi
     end
 
     test "update_pdf uses default when blank" do
       sign_in @admin
       Setting.pdf_max_pages = 50
+      Setting.pdf_dpi = 200
 
       patch update_pdf_admin_settings_path, params: {
-        pdf_settings: { max_pages: "" }
+        pdf_settings: { max_pages: "", dpi: "" }
       }
 
       assert_redirected_to admin_settings_path(anchor: "collapseUserFiles")
       assert_equal Setting::DEFAULT_PDF_MAX_PAGES, Setting.pdf_max_pages
+      assert_equal Setting::DEFAULT_PDF_DPI, Setting.pdf_dpi
     end
 
     test "update_pdf validates max pages range" do
@@ -341,6 +344,16 @@ module Admin
 
       patch update_pdf_admin_settings_path, params: {
         pdf_settings: { max_pages: 101 }
+      }
+
+      assert_response :unprocessable_entity
+    end
+
+    test "update_pdf validates dpi option" do
+      sign_in @admin
+
+      patch update_pdf_admin_settings_path, params: {
+        pdf_settings: { max_pages: 20, dpi: 72 }
       }
 
       assert_response :unprocessable_entity

--- a/test/models/setting_test.rb
+++ b/test/models/setting_test.rb
@@ -51,6 +51,21 @@ class SettingTest < ActiveSupport::TestCase
     assert_equal 1024, Setting.max_storage_per_user_mb
   end
 
+  test "pdf settings have correct defaults" do
+    assert_equal 20, Setting.pdf_max_pages
+    assert_equal 120, Setting.effective_pdf_dpi
+  end
+
+  test "effective_pdf_dpi returns configured option" do
+    Setting.pdf_dpi = 96
+    assert_equal 96, Setting.effective_pdf_dpi
+  end
+
+  test "effective_pdf_dpi returns default for unsupported value" do
+    Setting.pdf_dpi = 72
+    assert_equal Setting::DEFAULT_PDF_DPI, Setting.effective_pdf_dpi
+  end
+
   test "max_storage_bytes converts mb to bytes" do
     Setting.max_storage_per_user_mb = 100
     assert_equal 100.megabytes, Setting.max_storage_bytes

--- a/test/services/pdf_processing_service_test.rb
+++ b/test/services/pdf_processing_service_test.rb
@@ -5,6 +5,7 @@ require "test_helper"
 class PdfProcessingServiceTest < ActiveSupport::TestCase
   setup do
     Rails.cache.clear
+    Setting.pdf_dpi = Setting::DEFAULT_PDF_DPI
     @poppler_available = system("which pdfinfo > /dev/null 2>&1")
   end
 
@@ -47,6 +48,28 @@ class PdfProcessingServiceTest < ActiveSupport::TestCase
     assert_equal "document_2.jpg", result[1][:filename]
   end
 
+  test "convert_pdf_to_images は設定された DPI を pdftoppm に渡す" do
+    Setting.pdf_dpi = 96
+    service = PdfProcessingService.new("pdf data", "test.pdf")
+    status = Object.new
+    status.define_singleton_method(:success?) { true }
+    captured_args = nil
+    original_capture3 = Open3.method(:capture3)
+
+    Open3.define_singleton_method(:capture3) do |*args|
+      captured_args = args
+      [ "", "", status ]
+    end
+
+    begin
+      service.send(:convert_pdf_to_images, "input.pdf", "page")
+    ensure
+      Open3.define_singleton_method(:capture3, original_capture3)
+    end
+
+    assert_equal [ "pdftoppm", "-jpeg", "-r", "96", "input.pdf", "page" ], captured_args
+  end
+
   test "convert_to_images はページ上限を超えた場合 PageLimitExceededError を発生させる" do
     skip "poppler-utils がインストールされていません" unless @poppler_available
 
@@ -72,17 +95,19 @@ class PdfProcessingServiceTest < ActiveSupport::TestCase
 
   # Forms::PdfSettingsForm のテスト（poppler 不要）
   test "PdfSettingsForm は有効な値を保存できる" do
-    form = Forms::PdfSettingsForm.new(max_pages: 50)
+    form = Forms::PdfSettingsForm.new(max_pages: 50, dpi: 150)
     assert form.valid?
     assert form.save
     assert_equal 50, Setting.pdf_max_pages
+    assert_equal 150, Setting.pdf_dpi
   end
 
   test "PdfSettingsForm は空の場合デフォルト値を使用する" do
-    form = Forms::PdfSettingsForm.new(max_pages: "")
+    form = Forms::PdfSettingsForm.new(max_pages: "", dpi: "")
     assert form.valid?
     assert form.save
     assert_equal Setting::DEFAULT_PDF_MAX_PAGES, Setting.pdf_max_pages
+    assert_equal Setting::DEFAULT_PDF_DPI, Setting.pdf_dpi
   end
 
   test "PdfSettingsForm は 0 以下の値を拒否する" do
@@ -97,10 +122,18 @@ class PdfProcessingServiceTest < ActiveSupport::TestCase
     assert form.errors[:max_pages].present?
   end
 
+  test "PdfSettingsForm は選択肢外の DPI を拒否する" do
+    form = Forms::PdfSettingsForm.new(max_pages: 20, dpi: 72)
+    assert_not form.valid?
+    assert form.errors[:dpi].present?
+  end
+
   test "PdfSettingsForm は設定から値を読み込む" do
     Setting.pdf_max_pages = 30
+    Setting.pdf_dpi = 96
     form = Forms::PdfSettingsForm.new
     assert_equal 30, form.max_pages
+    assert_equal 96, form.dpi
   end
 
   private


### PR DESCRIPTION
PDF OCR時の画像変換DPIを管理画面から選択できるようにし、デフォルト値を200dpiから120dpiへ変更します。

## 背景

従来はPDFの各ページを常に200dpiのJPEGへ変換していました。A4では約1654 x 2339pxとなり、Vision LLMへ送信する画像サイズと処理時間が大きくなるため、通常文書向けの標準値を120dpiとし、必要に応じて速度または精度を選択できるようにします。

## 変更内容

- PDF変換DPIの設定を追加
  - 高速: 96dpi
  - 標準: 120dpi
  - 高精度: 150dpi
  - 最高精度: 200dpi
- デフォルト値を120dpiに設定
- 未設定値や選択肢外の値は120dpiへフォールバック
- `pdftoppm` の `-r` オプションへ設定済みDPIを渡すよう変更
- 管理画面のPDF設定にDPI選択欄を追加
- モデル、フォーム、コントローラー、PDF変換サービスのテストを追加・更新

## テスト

```console
bin/rails test test/models/setting_test.rb test/services/pdf_processing_service_test.rb test/controllers/admin/settings_controller_test.rb
```

分割前の統合差分では、上記を含む関連テストで `70 runs, 200 assertions, 0 failures, 0 errors, 0 skips` を確認済みです。
